### PR TITLE
feat: integrate Publidata alerts API and add alert sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ L’objectif est de pouvoir déclencher des automatisations (notifications, Tras
    - `metas.accepted_waste` / `rejected_waste` ;
    - `collection_mode` : ramassage devant la maison, dépôt, prise de RDV, etc.
 
+3. **Alertes** – récupérer les alertes et messages du service de collecte.
+   ```bash
+   curl 'https://api.publidata.io/v2/search?types[]=Alert&states[]=visible&include[]=*model_name&instances[]=876&order[desc]=published_at&address_id=<ID_ADRESSE>&size=5'
+   ```
+   La réponse contient :
+   - `name`: titre de l'alerte ;
+   - `alert_type`: type (`danger`, `warning`, `info`) ;
+   - `blurb`: contenu HTML du message ;
+   - `start_at` / `end_at`: période de validité.
+
 ---
 
 ### Installation du composant
@@ -36,7 +46,7 @@ L’objectif est de pouvoir déclencher des automatisations (notifications, Tras
 
 3. L’intégration interroge l’API Publidata :
    - Géocodage de l’adresse (une fois) ;
-   - récupération des collectes (au démarrage puis chaque semaine) ;
+   - récupération des collectes et des alertes (au démarrage puis chaque semaine) ;
    - génération d’évènements jusqu’à 90 jours à partir des horaires fournis.
 
 ---
@@ -45,7 +55,8 @@ L’objectif est de pouvoir déclencher des automatisations (notifications, Tras
 
 - `calendar.mel_collectes` : calendrier contenant l’ensemble des collectes ;
 - `sensor.prochaine_collecte` : date/heure ISO de la prochaine collecte ;
-- `sensor.collecte_<type>` : une entité par type (`omr`, `dv`, …) avec date de la prochaine collecte correspondante.
+- `sensor.collecte_<type>` : une entité par type (`omr`, `dv`, …) avec date de la prochaine collecte correspondante ;
+- `sensor.alertes_collecte` : nombre d'alertes actives du service, avec détails dans les attributs.
 
 Chaque entité expose des attributs (`mode`, `types`, `collection_id`, etc.) pour faciliter les automatisations/notifications.
 

--- a/custom_components/mel_collecte/api.py
+++ b/custom_components/mel_collecte/api.py
@@ -76,3 +76,28 @@ class MelCollecteAPI:
             payload = await response.json()
 
         return [hit["_source"] for hit in payload["hits"]["hits"]]
+
+    async def fetch_alerts(
+        self,
+        instance_id: str,
+        address_id: str,
+        size: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Récupère les alertes du service de collecte."""
+        params: list[tuple[str, str]] = [
+            ("types[]", "Alert"),
+            ("states[]", "visible"),
+            ("include[]", "*model_name"),
+            ("instances[]", instance_id),
+            ("order[desc]", "published_at"),
+            ("address_id", address_id),
+            ("size", str(size)),
+        ]
+
+        async with async_timeout.timeout(20):
+            response = await self._session.get(SEARCH_URL, params=params)
+            response.raise_for_status()
+            payload = await response.json()
+
+        return [hit["_source"] for hit in payload["hits"]["hits"]]
+

--- a/custom_components/mel_collecte/const.py
+++ b/custom_components/mel_collecte/const.py
@@ -24,7 +24,19 @@ GARBAGE_TYPES_LABELS = {
     "emb": "Emballages recyclables",
 }
 
+ALERT_TYPE_LABELS = {
+    "danger": "⚠️ Alerte",
+    "warning": "⚡ Avertissement",
+    "info": "ℹ️ Information",
+}
+
 
 def garbage_label(code: str) -> str:
     """Retourne un libellé humain pour le type de déchet."""
     return GARBAGE_TYPES_LABELS.get(code.lower(), code.upper())
+
+
+def alert_label(alert_type: str) -> str:
+    """Retourne un libellé humain pour le type d'alerte."""
+    return ALERT_TYPE_LABELS.get(alert_type.lower(), alert_type.capitalize())
+

--- a/custom_components/mel_collecte/coordinator.py
+++ b/custom_components/mel_collecte/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import MelCollecteAPI
-from .const import LOOKAHEAD_DAYS, UPDATE_INTERVAL_DAYS, garbage_label
+from .const import LOOKAHEAD_DAYS, UPDATE_INTERVAL_DAYS, alert_label, garbage_label
 from .parser import parse_schedule
 
 LOGGER = logging.getLogger(__name__)
@@ -60,6 +60,12 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 address_id=address_id,
                 lat=fetched_lat,
                 lon=fetched_lon,
+            )
+
+            # Fetch alerts from the service
+            alerts = await self.api.fetch_alerts(
+                instance_id=self.instance_id,
+                address_id=address_id,
             )
         except Exception as err:
             LOGGER.error("Erreur lors de la récupération des collectes: %s", err)
@@ -124,9 +130,25 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         events.sort(key=lambda item: item["start"])
 
+        # Parse alerts
+        parsed_alerts = [
+            {
+                "id": alert.get("id"),
+                "name": alert.get("name"),
+                "alert_type": alert.get("alert_type"),
+                "alert_type_friendly": alert_label(alert.get("alert_type", "")),
+                "blurb": alert.get("blurb"),
+                "start_at": alert.get("start_at"),
+                "end_at": alert.get("end_at"),
+                "published_at": alert.get("published_at"),
+            }
+            for alert in alerts
+        ]
+
         return {
             "address": self._address_payload,
             "collections": parsed_collections,
             "events": events,
+            "alerts": parsed_alerts,
             "fetched_at": now.isoformat(),
         }

--- a/custom_components/mel_collecte/sensor.py
+++ b/custom_components/mel_collecte/sensor.py
@@ -18,6 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
 
     entities: list[SensorEntity] = [
         MelCollecteNextSensor(coordinator, entry),
+        MelCollecteAlertSensor(coordinator, entry),
     ]
 
     seen_types: set[str] = set()
@@ -127,3 +128,45 @@ class MelCollecteTypeSensor(MelCollecteBaseSensor):
             if event["start"] >= now and self._type in event["garbage_types"]:
                 return event
         return None
+
+
+class MelCollecteAlertSensor(MelCollecteBaseSensor):
+    """Capteur pour les alertes du service de collecte."""
+
+    def __init__(self, coordinator, entry):
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_alerts"
+        self._attr_name = "Alertes collecte"
+        self._attr_icon = "mdi:alert-circle"
+
+    @property
+    def native_value(self):
+        """Retourne le nombre d'alertes actives."""
+        alerts = self._coordinator.data.get("alerts", [])
+        return len(alerts)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Retourne les détails des alertes."""
+        alerts = self._coordinator.data.get("alerts", [])
+        if not alerts:
+            return {"alerts": []}
+
+        return {
+            "alerts": [
+                {
+                    "id": alert.get("id"),
+                    "name": alert.get("name"),
+                    "type": alert.get("alert_type"),
+                    "type_friendly": alert.get("alert_type_friendly"),
+                    "message": alert.get("blurb"),
+                    "published_at": alert.get("published_at"),
+                    "end_at": alert.get("end_at"),
+                }
+                for alert in alerts
+            ],
+            "last_alert_name": alerts[0].get("name") if alerts else None,
+            "last_alert_type": alerts[0].get("alert_type") if alerts else None,
+            "last_alert_message": alerts[0].get("blurb") if alerts else None,
+        }
+

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -48,6 +48,11 @@ Cette documentation explique comment installer et configurer le composant person
   - `mode` (ramassage, dépôt, RDV…),
   - `debut` / `fin`.
 - `sensor.collecte_<type>` : un capteur par type détecté (`sensor.collecte_dechets_verts`, etc.).
+- `sensor.alertes_collecte` : nombre d'alertes actives du service de collecte, avec attributs :
+  - `alerts` : liste complète des alertes avec détails (id, nom, type, message, dates),
+  - `last_alert_name` : titre de la dernière alerte,
+  - `last_alert_type` : type de la dernière alerte (`danger`, `warning`, `info`),
+  - `last_alert_message` : contenu HTML de la dernière alerte.
 
 Tous les capteurs sont mis à jour automatiquement une fois par semaine + au démarrage.
 
@@ -105,6 +110,33 @@ pattern:
 ```
 
 > **Important** : `pattern` (champ de détection) doit correspondre exactement au libellé d’évènement du calendrier. Les capteurs fournissent la liste complète via l’attribut `types_friendly`; vous pouvez la consulter dans `Outils de développement → États`.
+
+---
+
+### 5.3 Carte des alertes
+
+Pour afficher les alertes du service de collecte, utilisez une carte Markdown :
+
+```yaml
+type: markdown
+title: 🚨 Alertes collecte
+content: |
+  {% set alerts = state_attr('sensor.alertes_collecte', 'alerts') %}
+  {% if alerts and alerts | length > 0 %}
+    {% for alert in alerts %}
+  ### {{ alert.type_friendly }} – {{ alert.name }}
+  {{ alert.message | regex_replace('<[^>]+>', '') | truncate(200) }}
+  
+  *Publié le {{ alert.published_at[:10] }}*
+  
+  ---
+    {% endfor %}
+  {% else %}
+  Aucune alerte en cours.
+  {% endif %}
+```
+
+Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, ℹ️ Information), titre, et message.
 
 ---
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -33,6 +33,9 @@ class DummyAPI:
             }
         ]
 
+    async def fetch_alerts(self, **kwargs):
+        return []
+
 
 @pytest.mark.asyncio
 async def test_coordinator_builds_events(monkeypatch):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -138,3 +138,73 @@ def test_type_sensor_name_and_value():
 
     assert sensor.name == "Collecte Déchets verts"
     assert value == "2025-01-09T00:00:00+00:00"
+
+
+def test_alert_sensor_count_and_attributes():
+    """Test du capteur d'alertes."""
+    from custom_components.mel_collecte.sensor import MelCollecteAlertSensor
+
+    sample_alerts = [
+        {
+            "id": 5534,
+            "name": "Conditions météorologiques",
+            "alert_type": "danger",
+            "alert_type_friendly": "⚠️ Alerte",
+            "blurb": "<p>Suite aux derniers mouvements sociaux...</p>",
+            "start_at": "2026-01-06T08:11:00.000Z",
+            "end_at": "2026-01-10T17:00:00.000Z",
+            "published_at": "2026-01-06T08:11:00.000Z",
+        },
+        {
+            "id": 5411,
+            "name": "Encombrants sur Rendez-Vous",
+            "alert_type": "info",
+            "alert_type_friendly": "ℹ️ Information",
+            "blurb": "<p>À partir du 1er janvier 2026...</p>",
+            "start_at": "2026-01-01T07:00:00.000Z",
+            "end_at": "2026-02-01T07:00:00.000Z",
+            "published_at": "2026-01-01T07:00:00.000Z",
+        },
+    ]
+
+    class AlertCoordinator:
+        def __init__(self, alerts):
+            self.data = {"events": [], "collections": [], "alerts": alerts}
+
+        async def async_request_refresh(self):
+            return None
+
+    coordinator = AlertCoordinator(sample_alerts)
+    entry = SimpleNamespace(entry_id="test")
+    sensor = MelCollecteAlertSensor(coordinator, entry)
+
+    # Test native value (count)
+    assert sensor.native_value == 2
+
+    # Test attributes
+    attrs = sensor.extra_state_attributes
+    assert "alerts" in attrs
+    assert len(attrs["alerts"]) == 2
+    assert attrs["last_alert_name"] == "Conditions météorologiques"
+    assert attrs["last_alert_type"] == "danger"
+
+
+def test_alert_sensor_empty():
+    """Test du capteur d'alertes sans alertes."""
+    from custom_components.mel_collecte.sensor import MelCollecteAlertSensor
+
+    class AlertCoordinator:
+        def __init__(self):
+            self.data = {"events": [], "collections": [], "alerts": []}
+
+        async def async_request_refresh(self):
+            return None
+
+    coordinator = AlertCoordinator()
+    entry = SimpleNamespace(entry_id="test")
+    sensor = MelCollecteAlertSensor(coordinator, entry)
+
+    assert sensor.native_value == 0
+    attrs = sensor.extra_state_attributes
+    assert attrs["alerts"] == []
+


### PR DESCRIPTION
## Summary
This PR integrates the Publidata alerts API into the MEL garbage collection extension. It adds a new sensor to display service alerts and messages, allowing users to stay informed about service disruptions or important notifications.

## Changes
- **API Layer**: Added  method to  to retrieve active alerts from Publidata.
- **Coordinator**: Updated  to fetch alerts during the regular update cycle and parse them into a friendly format.
- **Entities**: Created  (`sensor.alertes_collecte`) which:
  - Displays the count of active alerts as its state.
  - Provides detailed alert information (name, type, message, dates) in its attributes.
- **Documentation**: 
  - Updated `README.md` with new API endpoints and entity details.
  - Updated `docs/guide_utilisateur.md` with setup instructions and a Lovelace Markdown card example for displaying alerts.
- **Testing**:
  - Added unit tests for the alert sensor in `tests/test_entities.py`.
## Changes
- **API Layer*in `tests/test_const.py` to support the new method.

## Verification
- Ran `pytest` and confirmed all 7 tests pass.
- Verified that attribute mapping for alert types (`danger`, `warning`, `info`) works as expec- **Coordinator**: Updated  to fetch al