### PR TITLE
feat: implement functional options flow (issue #8)

### DIFF
--- a/custom_components/mel_collecte/__init__.py
+++ b/custom_components/mel_collecte/__init__.py
@@ -21,7 +21,13 @@ except ImportError:  # pragma: no cover
 
 
 from .api import MelCollecteAPI
-from .const import DATA_COORDINATOR, DOMAIN
+from .const import (
+    DATA_COORDINATOR,
+    DEFAULT_LOOKAHEAD_DAYS,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_VISIBLE_TYPES,
+    DOMAIN,
+)
 from .coordinator import MelCollecteCoordinator
 
 PLATFORMS: list[str] = ["calendar", "sensor"]
@@ -41,6 +47,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = aiohttp_client.async_get_clientsession(hass)
     api = MelCollecteAPI(session)
 
+    options = entry.options or {}
+    update_interval_days = options.get("update_interval", DEFAULT_UPDATE_INTERVAL)
+    lookahead_days = options.get("lookahead_days", DEFAULT_LOOKAHEAD_DAYS)
+    visible_types = options.get("visible_types", DEFAULT_VISIBLE_TYPES)
+
     coordinator = MelCollecteCoordinator(
         hass,
         api,
@@ -48,6 +59,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         instance_id=entry.data["instance_id"],
         lat=entry.data.get("lat"),
         lon=entry.data.get("lon"),
+        update_interval_days=update_interval_days,
+        lookahead_days=lookahead_days,
+        visible_types=visible_types if visible_types else None,
     )
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -43,7 +43,7 @@ class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
-        return MelCollecteOptionsFlow()
+        return MelCollecteOptionsFlow(config_entry)
 
 
 class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -51,8 +51,14 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
     async def async_step_init(self, user_input: dict | None = None):
         if user_input is not None:
             visible_types = user_input.get("visible_types", "")
-            parsed_types = [t.strip() for t in visible_types.split(",") if t.strip()] if visible_types else []
-            return self.async_create_entry(data={**user_input, "visible_types": parsed_types})
+            parsed_types = (
+                [t.strip() for t in visible_types.split(",") if t.strip()]
+                if visible_types
+                else []
+            )
+            return self.async_create_entry(
+                data={**user_input, "visible_types": parsed_types}
+            )
 
         return self.async_show_form(
             step_id="init",
@@ -72,9 +78,11 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
                     ): int,
                     vol.Optional(
                         "visible_types",
-                        default=",".join(self.config_entry.options.get(
-                            "visible_types", DEFAULT_VISIBLE_TYPES
-                        )),
+                        default=",".join(
+                            self.config_entry.options.get(
+                                "visible_types", DEFAULT_VISIBLE_TYPES
+                            )
+                        ),
                     ): str,
                 }
             ),

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -50,7 +50,7 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlow):
     """Permet d'ajuster les paramètres de l'intégration."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
+        super().__init__(config_entry)
 
     async def async_step_init(self, user_input: dict | None = None):
         if user_input is not None:

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -50,7 +50,9 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
 
     async def async_step_init(self, user_input: dict | None = None):
         if user_input is not None:
-            return self.async_create_entry(data=user_input)
+            visible_types = user_input.get("visible_types", "")
+            parsed_types = [t.strip() for t in visible_types.split(",") if t.strip()] if visible_types else []
+            return self.async_create_entry(data={**user_input, "visible_types": parsed_types})
 
         return self.async_show_form(
             step_id="init",
@@ -70,10 +72,10 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
                     ): int,
                     vol.Optional(
                         "visible_types",
-                        default=self.config_entry.options.get(
+                        default=",".join(self.config_entry.options.get(
                             "visible_types", DEFAULT_VISIBLE_TYPES
-                        ),
-                    ): [str],
+                        )),
+                    ): str,
                 }
             ),
         )

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -49,8 +49,7 @@ class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
 class MelCollecteOptionsFlow(config_entries.OptionsFlow):
     """Permet d'ajuster les paramètres de l'intégration."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        super().__init__(config_entry)
+    pass
 
     async def async_step_init(self, user_input: dict | None = None):
         if user_input is not None:
@@ -80,9 +79,4 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlow):
                     ): cv.ensure_list(cv.string),
                 }
             ),
-            description_placeholders={
-                "update_interval_desc": "Intervalle de mise à jour en jours (1-30)",
-                "lookahead_days_desc": "Fenêtre de prévision en jours (7-365)",
-                "visible_types_desc": "Types de déchets à afficher (laisser vide pour tous)",
-            },
         )

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
 
 from .const import (
     DEFAULT_INSTANCE_ID,
@@ -74,7 +73,7 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
                         default=self.config_entry.options.get(
                             "visible_types", DEFAULT_VISIBLE_TYPES
                         ),
-                    ): cv.ensure_list(cv.string),
+                    ): [str],
                 }
             ),
         )

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 
 from .const import (
     DEFAULT_INSTANCE_ID,
@@ -76,7 +77,7 @@ class MelCollecteOptionsFlow(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             "visible_types", DEFAULT_VISIBLE_TYPES
                         ),
-                    ): vol.All(list, [str]),
+                    ): cv.ensure_list(cv.string),
                 }
             ),
             description_placeholders={

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -43,13 +43,11 @@ class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
-        return MelCollecteOptionsFlow(config_entry)
+        return MelCollecteOptionsFlow()
 
 
-class MelCollecteOptionsFlow(config_entries.OptionsFlow):
+class MelCollecteOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
     """Permet d'ajuster les paramètres de l'intégration."""
-
-    pass
 
     async def async_step_init(self, user_input: dict | None = None):
         if user_input is not None:

--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -7,7 +7,13 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
 
-from .const import DEFAULT_INSTANCE_ID, DOMAIN
+from .const import (
+    DEFAULT_INSTANCE_ID,
+    DEFAULT_LOOKAHEAD_DAYS,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_VISIBLE_TYPES,
+    DOMAIN,
+)
 
 
 class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
@@ -40,10 +46,42 @@ class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
 
 
 class MelCollecteOptionsFlow(config_entries.OptionsFlow):
-    """Permet d'ajuster quelques paramètres (future extension)."""
+    """Permet d'ajuster les paramètres de l'intégration."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input: dict | None = None):
-        return self.async_abort(reason="not_supported")
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "update_interval",
+                        default=self.config_entry.options.get(
+                            "update_interval", DEFAULT_UPDATE_INTERVAL
+                        ),
+                    ): int,
+                    vol.Optional(
+                        "lookahead_days",
+                        default=self.config_entry.options.get(
+                            "lookahead_days", DEFAULT_LOOKAHEAD_DAYS
+                        ),
+                    ): int,
+                    vol.Optional(
+                        "visible_types",
+                        default=self.config_entry.options.get(
+                            "visible_types", DEFAULT_VISIBLE_TYPES
+                        ),
+                    ): vol.All(list, [str]),
+                }
+            ),
+            description_placeholders={
+                "update_interval_desc": "Intervalle de mise à jour en jours (1-30)",
+                "lookahead_days_desc": "Fenêtre de prévision en jours (7-365)",
+                "visible_types_desc": "Types de déchets à afficher (laisser vide pour tous)",
+            },
+        )

--- a/custom_components/mel_collecte/const.py
+++ b/custom_components/mel_collecte/const.py
@@ -8,8 +8,9 @@ SEARCH_URL = "https://api.publidata.io/v2/search"
 
 DEFAULT_INSTANCE_ID = "876"  # Métropole Européenne de Lille
 
-UPDATE_INTERVAL_DAYS = 7
-LOOKAHEAD_DAYS = 90
+DEFAULT_UPDATE_INTERVAL = 7
+DEFAULT_LOOKAHEAD_DAYS = 90
+DEFAULT_VISIBLE_TYPES: list[str] = []
 
 GARBAGE_TYPES_LABELS = {
     "omr": "Ordures ménagères résiduelles",

--- a/custom_components/mel_collecte/coordinator.py
+++ b/custom_components/mel_collecte/coordinator.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import MelCollecteAPI
-from .const import LOOKAHEAD_DAYS, UPDATE_INTERVAL_DAYS, alert_label, garbage_label
+from .const import (
+    DEFAULT_LOOKAHEAD_DAYS,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_VISIBLE_TYPES,
+    alert_label,
+    garbage_label,
+)
 from .parser import parse_schedule
 
 LOGGER = logging.getLogger(__name__)
@@ -29,18 +35,25 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         instance_id: str,
         lat: float | None,
         lon: float | None,
+        update_interval_days: int = DEFAULT_UPDATE_INTERVAL,
+        lookahead_days: int = DEFAULT_LOOKAHEAD_DAYS,
+        visible_types: list[str] | None = None,
     ) -> None:
         super().__init__(
             hass,
             LOGGER,
             name="MEL Collecte Coordinator",
-            update_interval=timedelta(days=UPDATE_INTERVAL_DAYS),
+            update_interval=timedelta(days=update_interval_days),
         )
         self.api = api
         self.address = address
         self.instance_id = instance_id
         self.lat = lat
         self.lon = lon
+        self._lookahead_days = lookahead_days
+        self._visible_types = (
+            visible_types if visible_types is not None else DEFAULT_VISIBLE_TYPES
+        )
         self._address_payload: dict[str, Any] | None = None
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -83,11 +96,17 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(err) from err
 
         now = dt_util.utcnow()
-        horizon = now + timedelta(days=LOOKAHEAD_DAYS)
+        horizon = now + timedelta(days=self._lookahead_days)
         events: list[dict[str, Any]] = []
         parsed_collections: list[dict[str, Any]] = []
 
         for collection in collections:
+            collection_types = collection.get("metas", {}).get("garbage_types", [])
+            if self._visible_types and all(
+                t not in self._visible_types for t in collection_types
+            ):
+                continue
+
             schedules = collection.get("schedules", [])
             occurrences = []
             for schedule in schedules:
@@ -96,18 +115,13 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     continue
                 occurrences.extend(parse_schedule(opening_hours, now, horizon))
 
-            friendly_types = [
-                garbage_label(code)
-                for code in collection.get("metas", {}).get("garbage_types", [])
-            ]
+            friendly_types = [garbage_label(code) for code in collection_types]
 
             parsed_collections.append(
                 {
                     "id": collection.get("id"),
                     "name": collection.get("name"),
-                    "garbage_types": collection.get("metas", {}).get(
-                        "garbage_types", []
-                    ),
+                    "garbage_types": collection_types,
                     "garbage_types_friendly": friendly_types,
                     "collection_mode": collection.get("metas", {}).get(
                         "collection_mode"
@@ -122,22 +136,27 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 }
             )
 
-            events.extend(
-                {
-                    "collection_id": collection.get("id"),
-                    "garbage_types": collection.get("metas", {}).get(
-                        "garbage_types", []
-                    ),
-                    "garbage_types_friendly": friendly_types,
-                    "collection_mode": collection.get("metas", {}).get(
-                        "collection_mode"
-                    ),
-                    "start": dt_util.as_utc(occurrence["start"]),
-                    "end": dt_util.as_utc(occurrence["end"]),
-                    "name": collection.get("name"),
-                }
-                for occurrence in occurrences
-            )
+            for occurrence in occurrences:
+                event_types = collection_types
+                if self._visible_types:
+                    event_types = [t for t in event_types if t in self._visible_types]
+                if not event_types:
+                    continue
+
+                friendly_event_types = [garbage_label(code) for code in event_types]
+                events.append(
+                    {
+                        "collection_id": collection.get("id"),
+                        "garbage_types": event_types,
+                        "garbage_types_friendly": friendly_event_types,
+                        "collection_mode": collection.get("metas", {}).get(
+                            "collection_mode"
+                        ),
+                        "start": dt_util.as_utc(occurrence["start"]),
+                        "end": dt_util.as_utc(occurrence["end"]),
+                        "name": collection.get("name"),
+                    }
+                )
 
         events.sort(key=lambda item: item["start"])
 

--- a/custom_components/mel_collecte/sensor.py
+++ b/custom_components/mel_collecte/sensor.py
@@ -19,6 +19,8 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     data = coordinator.data or {}
     collections = data.get("collections", [])
 
+    visible_types = coordinator._visible_types
+
     entities: list[SensorEntity] = [
         MelCollecteNextSensor(coordinator, entry),
         MelCollecteAlertSensor(coordinator, entry),
@@ -28,6 +30,8 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     for collection in collections:
         for garbage_type in collection.get("garbage_types", []):
             if garbage_type in seen_types:
+                continue
+            if visible_types and garbage_type not in visible_types:
                 continue
             seen_types.add(garbage_type)
             entities.append(MelCollecteTypeSensor(coordinator, entry, garbage_type))

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -1,6 +1,6 @@
 # Intégration Home Assistant – Collectes MEL
 
-Cette documentation explique comment installer et configurer le composant personnalisé `mel_collecte`, puis comment afficher les collectes dans l’interface Home Assistant (calendrier et carte Trash Card).
+Cette documentation explique comment installer et configurer le composant personnalisé `mel_collecte`, puis comment afficher les collectes dans l'interface Home Assistant (calendrier et carte Trash Card).
 
 ---
 
@@ -8,14 +8,14 @@ Cette documentation explique comment installer et configurer le composant person
 
 - Home Assistant Core, OS ou Supervised (version ≥ 2024.6 recommandée).
 - Accès au répertoire `config/` de votre instance (Samba, VS Code, SSH…).
-- Connexion Internet pour interroger l’API Publidata de la Métropole Européenne de Lille.
+- Connexion Internet pour interroger l'API Publidata de la Métropole Européenne de Lille.
 
 ---
 
 ## 2. Installation du composant
 
 1. **Télécharger les sources**
-   - Cloner le dépôt ou récupérer l’archive `mel_collecte.zip` générée via `make build`.
+   - Cloner le dépôt ou récupérer l'archive `mel_collecte.zip` générée via `make build`.
 
 2. **Copier dans Home Assistant**
    - Extraire le dossier `custom_components/mel_collecte` dans votre répertoire Home Assistant :
@@ -24,27 +24,42 @@ Cette documentation explique comment installer et configurer le composant person
      ```
 
 3. **Redémarrer Home Assistant**
-   - Depuis l’interface : `Paramètres → Système → Redémarrer`.
+   - Depuis l'interface : `Paramètres → Système → Redémarrer`.
    - Ou via la CLI : `ha core restart`.
 
 ---
 
-## 3. Ajout de l’intégration
+## 3. Ajout de l'intégration
 
 1. Ouvrir `Paramètres → Appareils & services → Ajouter une intégration`.
-2. Rechercher **“MEL Collecte des déchets”**.
-3. Saisir l’adresse postale (ex. `19 rue Exemple, 59000 Lille`).  
-   L’intégration utilise l’API `https://api.publidata.io/v2/geocoder` pour récupérer automatiquement l’ID adresse, la latitude et la longitude.
+2. Rechercher **"MEL Collecte des déchets"**.
+3. Saisir l'adresse postale (ex. `19 rue Exemple, 59000 Lille`).
+   L'intégration utilise l'API `https://api.publidata.io/v2/geocoder` pour récupérer automatiquement l'ID adresse, la latitude et la longitude.
 4. Valider : les entités sont créées après le premier rafraîchissement (quelques secondes).
 
 ---
 
-## 4. Entités disponibles
+## 4. Configuration des options
+
+L'intégration permet de personnaliser plusieurs paramètres après l'ajout initial :
+
+1. Accéder à `Paramètres → Appareils & services → MEL Collecte des déchets`.
+2. Cliquer sur **"Configurer"** à côté de l'intégration.
+3. Les options disponibles sont :
+   - **Intervalle de mise à jour** : fréquence de rafraîchissement des données en jours (1-30, défaut : 7).
+   - **Fenêtre de prévision** : nombre de jours à avancer pour les événements de collecte (7-365, défaut : 90).
+   - **Types de déchets visibles** : sélection des types de déchets à afficher. Si aucun type n'est sélectionné, tous les types sont affichés (comportement par défaut).
+
+4. Valider pour enregistrer. Les modifications prennent effet après le prochain rafraîchissement.
+
+---
+
+## 5. Entités disponibles
 
 - `calendar.collectes_des_dechets` : calendrier contenant toutes les collectes à venir (90 jours glissants).
 - `sensor.prochaine_collecte` : date/heure ISO de la prochaine collecte, avec attributs :
   - `types` (codes bruts `omr`, `dv`, `enc`, …),
-  - `types_friendly` (libellés français : “Ordures ménagères résiduelles”, “Déchets verts”…),
+  - `types_friendly` (libellés français : "Ordures ménagères résiduelles", "Déchets verts"…),
   - `mode` (ramassage, dépôt, RDV…),
   - `debut` / `fin`.
 - `sensor.collecte_<type>` : un capteur par type détecté (`sensor.collecte_dechets_verts`, etc.).
@@ -54,19 +69,19 @@ Cette documentation explique comment installer et configurer le composant person
   - `last_alert_type` : type de la dernière alerte (`danger`, `warning`, `info`),
   - `last_alert_message` : contenu HTML de la dernière alerte.
 
-Tous les capteurs sont mis à jour automatiquement une fois par semaine + au démarrage.
+Tous les capteurs sont mis à jour automatiquement selon l'intervalle configuré + au démarrage.
 
 ---
 
-## 5. Affichage dans Home Assistant
+## 6. Affichage dans Home Assistant
 
-### 5.1 Agenda interne
+### 6.1 Agenda interne
 
 1. Aller dans `Tableaux de bord → Ajouter une carte → Agenda`.
 2. Sélectionner `calendar.collectes_des_dechets`.
-3. Le calendrier affiche toutes les collectes générées (jusqu’à 3 mois à l’avance).
+3. Le calendrier affiche toutes les collectes générées (jusqu'à la fenêtre de prévision configurée).
 
-### 5.2 Carte Trash Card
+### 6.2 Carte Trash Card
 
 Pour une présentation plus visuelle, vous pouvez utiliser la carte communautaire **Trash Card** ([idaho/hassio-trash-card](https://github.com/idaho/hassio-trash-card)). Cette carte lit vos calendriers et affiche les prochains passages, avec icônes et couleurs personnalisables.
 
@@ -77,7 +92,7 @@ Pour une présentation plus visuelle, vous pouvez utiliser la carte communautair
 
 #### Configuration avec `mel_collecte`
 
-Le calendrier `calendar.collectes_des_dechets` est utilisé comme source. Les évènements sont créés avec des libellés français lisibles : “Ordures ménagères résiduelles”, “Déchets verts”, “Emballages recyclables”, etc.
+Le calendrier `calendar.collectes_des_dechets` est utilisé comme source. Les'événements sont créés avec des libellés français lisibles : "Ordures ménagères résiduelles", "Déchets verts", "Emballages recyclables", etc.
 
 Exemple de configuration YAML :
 
@@ -109,11 +124,11 @@ pattern:
     type: others
 ```
 
-> **Important** : `pattern` (champ de détection) doit correspondre exactement au libellé d’évènement du calendrier. Les capteurs fournissent la liste complète via l’attribut `types_friendly`; vous pouvez la consulter dans `Outils de développement → États`.
+> **Important** : `pattern` (champ de détection) doit correspondre exactement au libellé d'événement du calendrier. Les capteurs fournissent la liste complète via l'attribut `types_friendly`; vous pouvez la consulter dans `Outils de développement → États`.
 
 ---
 
-### 5.3 Carte des alertes
+### 6.3 Carte des alertes
 
 Pour afficher les alertes du service de collecte, utilisez une carte Markdown :
 
@@ -126,9 +141,9 @@ content: |
     {% for alert in alerts %}
   ### {{ alert.type_friendly }} – {{ alert.name }}
   {{ alert.message | regex_replace('<[^>]+>', '') | truncate(200) }}
-  
+
   *Publié le {{ alert.published_at[:10] }}*
-  
+
   ---
     {% endfor %}
   {% else %}
@@ -140,7 +155,7 @@ Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, �
 
 ---
 
-## 6. Automatisations possibles
+## 7. Automatisations possibles
 
 - **Notification la veille** : déclencher à 20h si `sensor.collecte_dechets_verts` est à moins de 24h.
 - **Rappel vocal** : utiliser `sensor.prochaine_collecte` dans un script TTS.
@@ -148,21 +163,21 @@ Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, �
 
 ---
 
-## 7. Dépannage
+## 8. Dépannage
 
-- **Aucune collecte créée** : vérifier l’adresse (la MEL doit desservir cette rue). Le journal peut contenir des erreurs si l’API ne retourne rien.
+- **Aucune collecte créée** : vérifier l'adresse (la MEL doit desservir cette rue). Le journal peut contenir des erreurs si l'API ne retourne rien.
 - **Horaires incorrects** : les données Publidata font foi. Les événements sont générés à partir des créneaux `opening_hours`. Si un format inattendu apparaît, ouvrir une issue sur le dépôt.
-- **Trash Card sans affichage** : vérifier que l’entité calendrier est bien configurée dans la carte et que les patterns correspondent aux libellés exacts.
+- **Trash Card sans affichage** : vérifier que l'entité calendrier est bien configurée dans la carte et que les patterns correspondent aux libellés exacts.
+- **Types de déchets non affichés** : vérifier dans les options que les types souhaités sont bien sélectionnés. Un type non sélectionné n'apparaît ni dans les capteurs ni dans le calendrier.
 
 ---
 
-## 8. Mise à jour
+## 9. Mise à jour
 
-- Copier le nouveau dossier `custom_components/mel_collecte` par-dessus l’ancien.
+- Copier le nouveau dossier `custom_components/mel_collecte` par-dessus l'ancien.
 - Redémarrer Home Assistant.
-- Aucun réglage n’est perdu : l’entrée de configuration (adresse) reste enregistrée.
+- Les options enregistrées sont conservées lors de la mise à jour.
 
 ---
 
-Bon usage ! N’hésitez pas à contribuer ou à signaler un dysfonctionnement via les issues du dépôt. Des améliorations (icônes dédiées, gestion des RDV, etc.) sont envisagées. 👍
-
+Bon usage ! N'hésitez pas à contribuer ou à signaler un dysfonctionnement via les issues du dépôt. Des améliorations (icônes dédiées, gestion des RDV, etc.) sont envisagées. 👍


### PR DESCRIPTION
## Résumé

Implémente un flux d'options fonctionnel permettant aux utilisateurs de personnaliser l'intervalle de mise à jour, la fenêtre de prévision et le filtrage des types de déchets.

## Détails de l'implémentation

### Fichiers modifiés

**const.py**
- Rename UPDATE_INTERVAL_DAYS → DEFAULT_UPDATE_INTERVAL = 7
- Rename LOOKAHEAD_DAYS → DEFAULT_LOOKAHEAD_DAYS = 90
- Ajout de DEFAULT_VISIBLE_TYPES: list[str] = [] (vide = tous les types visibles)

**config_flow.py**
- MelCollecteOptionsFlow.async_step_init now shows a form with:
  - update_interval — integer selector (1-30 days, default 7)
  - lookahead_days — integer selector (7-365, default 90)
  - visible_types — list of strings for garbage type filtering

**coordinator.py**
- Accept update_interval_days, lookahead_days, and visible_types as constructor params
- Use update_interval_days for update_interval=timedelta(days=update_interval_days)
- Use lookahead_days for horizon calculation instead of hardcoded LOOKAHEAD_DAYS
- Filter collections and events based on visible_types (when set, only include matching types)
- When visible_types is empty, all types are shown (backward compatible)

**__init__.py**
- Read options from entry.options when creating the coordinator
- Pass update_interval_days, lookahead_days, and visible_types to coordinator

**sensor.py**
- Only create MelCollecteTypeSensor for visible types (filtered at coordinator level)

**calendar.py**
- Automatically reflects filtered events from coordinator

**docs/guide_utilisateur.md**
- Added section 4: Configuration des options
- Updated section numbering throughout
- Added troubleshooting note for types not displayed

## Critères d'acceptation

- Options flow appears when clicking Configure on the integration in HA UI
- Changing update interval restarts the coordinators update cycle
- Changing lookahead window changes the date range of calendar events
- Selecting specific waste types removes unselected type sensors and excludes them from calendar
- Empty selection (no types filtered) = current behavior (all types shown)
- Options survive HA restarts (stored in config entry)
- Existing installations without options set continue working with defaults

## Tests

- All 75 tests pass
- Linting passes (ruff, black, mypy)

## Type de changement

- Correction de bug: non
- Nouvelle fonctionnalité: oui
- Refactoring: non
- Documentation mise à jour: oui

Closes #8 