### PR TITLE
feat: add address validation and coverage area check during config flow

### DIFF
--- a/custom_components/mel_collecte/config_flow.py
+++ b/custom_components/mel_collecte/config_flow.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import MelCollecteAPI
 from .const import (
     DEFAULT_INSTANCE_ID,
     DEFAULT_LOOKAHEAD_DAYS,
@@ -30,6 +34,49 @@ class MelCollecteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
 
         await self.async_set_unique_id(user_input[CONF_ADDRESS])
         self._abort_if_unique_id_configured()
+
+        session = async_get_clientsession(self.hass)
+        api = MelCollecteAPI(session)
+
+        try:
+            feature = await asyncio.wait_for(
+                api.geocode_address(user_input[CONF_ADDRESS]), timeout=20
+            )
+        except asyncio.TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+        except ClientError:
+            return self.async_abort(reason="cannot_connect")
+
+        if feature is None:
+            return self.async_abort(reason="address_not_found")
+
+        properties = feature.get("properties", {})
+        address_id = properties.get("id")
+        if not address_id:
+            return self.async_abort(reason="outside_coverage")
+
+        geometry = feature.get("geometry", {})
+        coordinates = geometry.get("coordinates", [])
+        lat = coordinates[1] if len(coordinates) >= 2 else None
+        lon = coordinates[0] if len(coordinates) >= 2 else None
+
+        try:
+            collections = await asyncio.wait_for(
+                api.fetch_waste_collections(
+                    instance_id=DEFAULT_INSTANCE_ID,
+                    address_id=address_id,
+                    lat=lat,
+                    lon=lon,
+                ),
+                timeout=20,
+            )
+        except asyncio.TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+        except ClientError:
+            return self.async_abort(reason="cannot_connect")
+
+        if not collections:
+            return self.async_abort(reason="outside_coverage")
 
         return self.async_create_entry(
             title=user_input[CONF_ADDRESS],

--- a/custom_components/mel_collecte/strings.json
+++ b/custom_components/mel_collecte/strings.json
@@ -13,12 +13,11 @@
     },
     "error": {
       "cannot_connect": "Connexion impossible.",
-      "address_not_found": "Adresse introuvable. Vérifiez l'orthographe.",
-      "outside_coverage": "Cette adresse n'est pas desservie par la Métropole Européenne de Lille."
+      "address_not_found": "Adresse introuvable. Vérifiez l'orthographe."
     },
     "abort": {
-      "already_configured": "Cette adresse est déjà configurée."
+      "already_configured": "Cette adresse est déjà configurée.",
+      "outside_coverage": "Cette adresse n'est pas desservie par la Métropole Européenne de Lille."
     }
   }
 }
-

--- a/custom_components/mel_collecte/strings.json
+++ b/custom_components/mel_collecte/strings.json
@@ -12,7 +12,9 @@
       }
     },
     "error": {
-      "cannot_connect": "Connexion impossible."
+      "cannot_connect": "Connexion impossible.",
+      "address_not_found": "Adresse introuvable. Vérifiez l'orthographe.",
+      "outside_coverage": "Cette adresse n'est pas desservie par la Métropole Européenne de Lille."
     },
     "abort": {
       "already_configured": "Cette adresse est déjà configurée."

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -35,6 +35,7 @@ Cette documentation explique comment installer et configurer le composant person
 2. Rechercher **"MEL Collecte des déchets"**.
 3. Saisir l'adresse postale (ex. `19 rue Exemple, 59000 Lille`).
    L'intégration utilise l'API `https://api.publidata.io/v2/geocoder` pour récupérer automatiquement l'ID adresse, la latitude et la longitude.
+   L'adresse est validée en temps réel : si elle est introuvable ou si elle ne se situe pas dans la zone desservie par la Métropole Européenne de Lille, un message d'erreur explicite est affiché avant la création de l'entrée.
 4. Valider : les entités sont créées après le premier rafraîchissement (quelques secondes).
 
 ---

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ ruff
 black
 mypy
 async-timeout
+voluptuous
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,18 @@ def _ensure_module(name: str) -> types.ModuleType:
 # Crée les modules racine
 ha = _ensure_module("homeassistant")
 
+# ----- homeassistant.const ------------------------------------------------
+const_module = _ensure_module("homeassistant.const")
+const_module.CONF_ADDRESS = "address"
+ha.const = const_module
+
 # ----- homeassistant.core -------------------------------------------------
 core = _ensure_module("homeassistant.core")
+
+
+def callback(func):
+    """Simple callback decorator stub."""
+    return func
 
 
 class HomeAssistant:
@@ -31,6 +41,7 @@ class HomeAssistant:
         self.loop = loop
 
 
+core.callback = callback
 core.HomeAssistant = HomeAssistant
 ha.core = core
 
@@ -45,7 +56,51 @@ class ConfigEntry:  # pragma: no cover - stub simple
         self.__dict__.update(kwargs)
 
 
+class ConfigFlowMeta(type):
+    """Metaclass that accepts domain keyword."""
+
+    def __new__(mcs, name, bases, namespace, domain=None, **kwargs):
+        return super().__new__(mcs, name, bases, namespace)
+
+    def __init__(cls, name, bases, namespace, domain=None, **kwargs):
+        super().__init__(name, bases, namespace)
+
+
+class _ConfigFlowBase(metaclass=ConfigFlowMeta, domain=None):
+    VERSION = 1
+
+    def __init__(self, hass=None, **kwargs):
+        self.hass = hass
+
+    async def async_step_user(self, user_input=None):
+        return None
+
+    def async_show_form(self, **kwargs):
+        return {"type": "form", **kwargs}
+
+    def async_create_entry(self, **kwargs):
+        return {"type": "create_entry", **kwargs}
+
+    def async_abort(self, **kwargs):
+        return {"type": "abort", **kwargs}
+
+    async def async_set_unique_id(self, unique_id):
+        pass
+
+    def _abort_if_unique_id_configured(self):
+        pass
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return None
+
+
+ConfigFlow = _ConfigFlowBase
+
+
 config_entries.ConfigEntry = ConfigEntry
+config_entries.ConfigFlow = ConfigFlow
+config_entries.OptionsFlowWithConfigEntry = type("OptionsFlowWithConfigEntry", (), {})
 ha.config_entries = config_entries
 
 # ----- homeassistant.helpers.entity ---------------------------------------
@@ -238,10 +293,15 @@ sys.modules["homeassistant.util.dt"] = dt_module
 aiohttp_module = types.ModuleType("aiohttp")
 
 
+class ClientError(Exception):
+    """Simulates aiohttp.ClientError."""
+
+
 class ClientSession:  # pragma: no cover - simple stub
     """ClientSession factice pour éviter d'installer aiohttp."""
 
 
+aiohttp_module.ClientError = ClientError
 aiohttp_module.ClientSession = ClientSession
 sys.modules["aiohttp"] = aiohttp_module
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,226 @@
+"""Tests pour le config flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from custom_components.mel_collecte.config_flow import (
+    MelCollecteConfigFlow,
+)
+
+
+class DummyFlowResult:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class TestMelCollecteConfigFlow:
+    """Tests pour MelCollecteConfigFlow."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        return hass
+
+    @pytest.fixture
+    def mock_session(self):
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_address_not_found_aborts(self, mock_hass, mock_session):
+        """Une adresse non trouvée doit abort."""
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(return_value=None)
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=mock_session,
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "Invalid Address"})
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "address_not_found"
+
+    @pytest.mark.asyncio
+    async def test_address_without_id_aborts_outside_coverage(
+        self, mock_hass, mock_session
+    ):
+        """Une adresse sans id doit abort avec outside_coverage."""
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(
+            return_value={
+                "geometry": {"coordinates": [2.3, 48.9]},
+                "properties": {},
+            }
+        )
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=mock_session,
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user(
+                {"address": "38 rue marcel sembat paris"}
+            )
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "outside_coverage"
+
+    @pytest.mark.asyncio
+    async def test_valid_mel_address_creates_entry(self, mock_hass, mock_session):
+        """Une adresse MEL valide doit créer l'entrée."""
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(
+            return_value={
+                "geometry": {"coordinates": [3.0, 50.6]},
+                "properties": {"id": "MEL_ID_123"},
+            }
+        )
+        mock_api.fetch_waste_collections = AsyncMock(
+            return_value=[{"id": "COL_1", "name": "OMR"}]
+        )
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=mock_session,
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "5 rue de Lille, Lille"})
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == "5 rue de Lille, Lille"
+        assert result["data"]["address"] == "5 rue de Lille, Lille"
+        assert result["data"]["instance_id"] == "876"
+
+    @pytest.mark.asyncio
+    async def test_address_outside_mel_coverage_aborts(self, mock_hass, mock_session):
+        """Une adresse hors zone MEL (sans collectes) doit abort."""
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(
+            return_value={
+                "geometry": {"coordinates": [2.3, 48.9]},
+                "properties": {"id": "PARIS_ID_123"},
+            }
+        )
+        mock_api.fetch_waste_collections = AsyncMock(return_value=[])
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=mock_session,
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user(
+                {"address": "38 rue marcel sembat paris"}
+            )
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "outside_coverage"
+
+    @pytest.mark.asyncio
+    async def test_network_error_aborts_with_cannot_connect(self, mock_hass):
+        """Une erreur réseau doit abort avec cannot_connect."""
+        from aiohttp import ClientError
+
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(side_effect=ClientError())
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=MagicMock(),
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "Lille"})
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_aborts_with_cannot_connect(self, mock_hass):
+        """Un timeout doit abort avec cannot_connect."""
+        import asyncio
+
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=MagicMock(),
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "Lille"})
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_timeout_on_fetch_collections_aborts(self, mock_hass):
+        """Un timeout sur fetch_waste_collections doit abort."""
+        import asyncio
+
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(
+            return_value={
+                "geometry": {"coordinates": [3.0, 50.6]},
+                "properties": {"id": "MEL_ID"},
+            }
+        )
+        mock_api.fetch_waste_collections = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=MagicMock(),
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "Lille"})
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_client_error_on_fetch_collections_aborts(self, mock_hass):
+        """Une ClientError sur fetch_waste_collections doit abort."""
+        from aiohttp import ClientError
+
+        mock_api = MagicMock()
+        mock_api.geocode_address = AsyncMock(
+            return_value={
+                "geometry": {"coordinates": [3.0, 50.6]},
+                "properties": {"id": "MEL_ID"},
+            }
+        )
+        mock_api.fetch_waste_collections = AsyncMock(side_effect=ClientError())
+
+        with patch(
+            "custom_components.mel_collecte.config_flow.async_get_clientsession",
+            return_value=MagicMock(),
+        ), patch(
+            "custom_components.mel_collecte.config_flow.MelCollecteAPI",
+            return_value=mock_api,
+        ):
+            flow = MelCollecteConfigFlow(mock_hass)
+            result = await flow.async_step_user({"address": "Lille"})
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
## Summary
- Add address validation during config flow by calling geocode AND checking for waste collections
- Show clear user-friendly error messages when address is not found or outside MEL coverage
- Handle network errors gracefully with `cannot_connect` error

## Changes
- **config_flow.py**: After user submits address, call `geocode_address()` then `fetch_waste_collections()` to verify coverage. An address is only accepted if it returns at least one waste collection. This properly rejects Paris addresses (outside MEL coverage).
- **strings.json**: Added `address_not_found` and `outside_coverage` error messages
- **docs/guide_utilisateur.md**: Updated French documentation to mention real-time validation
- **tests/test_config_flow.py**: Added 8 tests covering all scenarios
- **tests/conftest.py**: Enhanced stubs to support config_flow testing (voluptuous, aiohttp.ClientError, ConfigFlow with domain kwarg)
- **requirements-dev.txt**: Added voluptuous for testing

## Acceptance Criteria
- Invalid address shows clear error in HA config flow UI before entry creation
- Address outside MEL shows specific error message
- Network errors show connection error
- Valid MEL address proceeds to entry creation as before
- No change in behavior for addresses already successfully configured

## Testing
- 83 tests passing (15 API + 8 config flow + 60 others)
- Lint and type checks pass

Closes #9
