### PR TITLE
feat: Add retry logic with exponential backoff for API calls

### DIFF
--- a/custom_components/mel_collecte/api.py
+++ b/custom_components/mel_collecte/api.py
@@ -2,18 +2,46 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
+import aiohttp
 import async_timeout
 from aiohttp import ClientSession
 
-from .const import GEO_URL, SEARCH_URL
+from .const import (
+    GEO_URL,
+    MAX_RETRIES,
+    RETRY_BASE_DELAY,
+    RETRY_MAX_DELAY,
+    SEARCH_URL,
+    PermanentError,
+    TransientError,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
 MAX_GEOCODE_CACHE_SIZE = 100
+
+# HTTP status codes that should never trigger a retry
+_NON_RETRIABLE_STATUS = {400, 401, 403, 404, 422}
+
+
+def _classify_http_error(status: int) -> None:
+    """Lève TransientError ou PermanentError selon le code HTTP.
+
+    Les erreurs 5xx et 429 sont transitoires (réseau, serveur surchargé).
+    Les erreurs 4xx (sauf 429) sont permanentes.
+    """
+    if status in _NON_RETRIABLE_STATUS:
+        raise PermanentError(f"HTTP {status} — erreur permanente, pas de nouvel essai")
+    if status == 429 or status >= 500:
+        raise TransientError(f"HTTP {status} — erreur transitoire, réessai en cours")
+    # autres 4xx non listés → permanentes par défaut
+    if status >= 400:
+        raise PermanentError(f"HTTP {status} — erreur permanente, pas de nouvel essai")
 
 
 class MelCollecteAPI:
@@ -22,6 +50,121 @@ class MelCollecteAPI:
     def __init__(self, session: ClientSession) -> None:
         self._session = session
         self._geocode_cache: dict[str, dict[str, Any]] = {}
+        self._last_error: str | None = None
+
+    @property
+    def last_error(self) -> str | None:
+        """Retourne le dernier message d'erreur enregistré."""
+        return self._last_error
+
+    async def _request_with_retry(
+        self,
+        url: str,
+        params: Any,
+    ) -> Any:
+        """Effectue une requête GET avec réessais et backoff exponentiel.
+
+        Réessaie en cas d'erreur transitoire jusqu'à MAX_RETRIES fois.
+        Respecte l'en-tête Retry-After en cas de HTTP 429.
+        Lève UpdateFailed (via TransientError/PermanentError) après épuisement.
+        """
+        last_exc: Exception | None = None
+
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                async with async_timeout.timeout(20):
+                    response = await self._session.get(url, params=params)
+
+                # Gestion HTTP 429 avec Retry-After
+                if response.status == 429:
+                    retry_after_raw = response.headers.get("Retry-After")
+                    try:
+                        delay = (
+                            min(float(retry_after_raw), RETRY_MAX_DELAY)
+                            if retry_after_raw
+                            else None
+                        )
+                    except (ValueError, TypeError):
+                        delay = None
+
+                    if delay is None:
+                        delay = min(
+                            RETRY_BASE_DELAY * (2**attempt),
+                            RETRY_MAX_DELAY,
+                        )
+
+                    if attempt < MAX_RETRIES:
+                        LOGGER.warning(
+                            "HTTP 429 reçu (tentative %d/%d), attente %.1fs avant réessai",
+                            attempt + 1,
+                            MAX_RETRIES,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+
+                    raise TransientError(
+                        f"HTTP 429 — limite de débit atteinte après {MAX_RETRIES} tentatives"
+                    )
+
+                # Gestion des autres erreurs HTTP
+                if response.status >= 400:
+                    _classify_http_error(response.status)
+
+                return await response.json()
+
+            except PermanentError:
+                # Ne pas réessayer : remonter immédiatement
+                raise
+            except TransientError as exc:
+                last_exc = exc
+                if attempt < MAX_RETRIES:
+                    delay = min(RETRY_BASE_DELAY * (2**attempt), RETRY_MAX_DELAY)
+                    LOGGER.warning(
+                        "Erreur transitoire (tentative %d/%d): %s — réessai dans %.1fs",
+                        attempt + 1,
+                        MAX_RETRIES,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    LOGGER.error(
+                        "Erreur transitoire persistante après %d tentatives: %s",
+                        MAX_RETRIES,
+                        exc,
+                    )
+                    raise
+            except (
+                aiohttp.ClientConnectorError,
+                aiohttp.ServerDisconnectedError,
+                asyncio.TimeoutError,
+            ) as exc:
+                last_exc = exc
+                if attempt < MAX_RETRIES:
+                    delay = min(RETRY_BASE_DELAY * (2**attempt), RETRY_MAX_DELAY)
+                    LOGGER.warning(
+                        "Erreur réseau (tentative %d/%d): %s — réessai dans %.1fs",
+                        attempt + 1,
+                        MAX_RETRIES,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    LOGGER.error(
+                        "Erreur réseau persistante après %d tentatives: %s",
+                        MAX_RETRIES,
+                        exc,
+                    )
+                    raise TransientError(
+                        f"Erreur réseau après {MAX_RETRIES} tentatives : {exc}"
+                    ) from exc
+
+        # Ce point ne devrait pas être atteint, mais par sécurité
+        raise TransientError(
+            f"Requête échouée après {MAX_RETRIES} tentatives : {last_exc}"
+        )
 
     async def geocode_address(
         self, address: str, citycode: str | None = None
@@ -39,10 +182,12 @@ class MelCollecteAPI:
         if citycode:
             params["citycode"] = citycode
 
-        async with async_timeout.timeout(20):
-            response = await self._session.get(GEO_URL, params=params)
-            response.raise_for_status()
-            payload = await response.json()
+        try:
+            payload = await self._request_with_retry(GEO_URL, params)
+            self._last_error = None
+        except (TransientError, PermanentError) as exc:
+            self._last_error = str(exc)
+            raise
 
         if not payload or not isinstance(payload, list) or not payload[0]:
             return None
@@ -80,10 +225,12 @@ class MelCollecteAPI:
                 ]
             )
 
-        async with async_timeout.timeout(20):
-            response = await self._session.get(SEARCH_URL, params=params)
-            response.raise_for_status()
-            payload = await response.json()
+        try:
+            payload = await self._request_with_retry(SEARCH_URL, params)
+            self._last_error = None
+        except (TransientError, PermanentError) as exc:
+            self._last_error = str(exc)
+            raise
 
         hits = payload.get("hits", {})
         hits_list = hits.get("hits")
@@ -108,10 +255,12 @@ class MelCollecteAPI:
             ("size", str(size)),
         ]
 
-        async with async_timeout.timeout(20):
-            response = await self._session.get(SEARCH_URL, params=params)
-            response.raise_for_status()
-            payload = await response.json()
+        try:
+            payload = await self._request_with_retry(SEARCH_URL, params)
+            self._last_error = None
+        except (TransientError, PermanentError) as exc:
+            self._last_error = str(exc)
+            raise
 
         hits = payload.get("hits", {})
         hits_list = hits.get("hits")

--- a/custom_components/mel_collecte/const.py
+++ b/custom_components/mel_collecte/const.py
@@ -12,6 +12,20 @@ DEFAULT_UPDATE_INTERVAL = 7
 DEFAULT_LOOKAHEAD_DAYS = 90
 DEFAULT_VISIBLE_TYPES: list[str] = []
 
+# Retry configuration
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1  # seconds
+RETRY_MAX_DELAY = 30  # seconds
+
+
+class TransientError(Exception):
+    """Erreur transitoire (réseau, timeout, limite de débit) — réessayable."""
+
+
+class PermanentError(Exception):
+    """Erreur permanente (adresse invalide, clé API incorrecte) — ne pas réessayer."""
+
+
 GARBAGE_TYPES_LABELS = {
     "omr": "Ordures ménagères résiduelles",
     "dv": "Déchets verts",

--- a/custom_components/mel_collecte/coordinator.py
+++ b/custom_components/mel_collecte/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -55,6 +55,7 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             visible_types if visible_types is not None else DEFAULT_VISIBLE_TYPES
         )
         self._address_payload: dict[str, Any] | None = None
+        self._last_update_success: datetime | None = None
 
     async def _async_update_data(self) -> dict[str, Any]:
         try:
@@ -92,7 +93,10 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 address_id=address_id,
             )
         except Exception as err:
-            LOGGER.error("Erreur lors de la récupération des collectes: %s", err)
+            LOGGER.warning(
+                "Erreur lors de la récupération des collectes (le coordonnateur réessaiera) : %s",
+                err,
+            )
             raise UpdateFailed(err) from err
 
         now = dt_util.utcnow()
@@ -175,10 +179,13 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for alert in alerts
         ]
 
+        self._last_update_success = datetime.now(timezone.utc)
+
         return {
             "address": self._address_payload,
             "collections": parsed_collections,
             "events": events,
             "alerts": parsed_alerts,
             "fetched_at": now.isoformat(),
+            "last_update_success": self._last_update_success.isoformat(),
         }

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -171,6 +171,23 @@ Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, �
 - **Trash Card sans affichage** : vérifier que l'entité calendrier est bien configurée dans la carte et que les patterns correspondent aux libellés exacts.
 - **Types de déchets non affichés** : vérifier dans les options que les types souhaités sont bien sélectionnés. Un type non sélectionné n'apparaît ni dans les capteurs ni dans le calendrier.
 
+### 8.1 Logique de réessai et gestion des erreurs
+
+L'intégration distingue deux catégories d'erreurs lors des appels à l'API Publidata :
+
+| Catégorie | Exemples | Comportement |
+|-----------|----------|-------------|
+| **Erreur transitoire** | Erreur réseau, timeout, HTTP 429 (trop de requêtes), HTTP 5xx | Réessai automatique jusqu'à 3 fois avec délai exponentiel (1 s, 2 s, 4 s) |
+| **Erreur permanente** | HTTP 400, 401, 403, 404 (adresse invalide, clé API incorrecte) | Aucun réessai — erreur remontée immédiatement |
+
+En cas de code HTTP **429 (Too Many Requests)**, l'en-tête `Retry-After` est respecté si présent ; sinon le backoff exponentiel s'applique avec un plafond de 30 secondes.
+
+Après épuisement de toutes les tentatives, le coordinateur marque la mise à jour comme échouée mais ne plante pas Home Assistant. La prochaine mise à jour planifiée repartira du début.
+
+**Suivi de la fraîcheur des données** : l'attribut `last_update_success` (disponible dans `Outils de développement → États` sur chaque entité) indique l'horodatage ISO de la dernière récupération réussie. Si cette valeur est ancienne alors que l'intégration semble active, vérifier le journal pour des erreurs transitoires répétées.
+
+**Consulter les journaux** : les erreurs transitoires sont consignées au niveau `WARNING` (pas `ERROR`), ce qui permet de les filtrer facilement dans `Paramètres → Système → Journaux`.
+
 ---
 
 ## 9. Mise à jour

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,7 +301,20 @@ class ClientSession:  # pragma: no cover - simple stub
     """ClientSession factice pour éviter d'installer aiohttp."""
 
 
+class ClientConnectorError(ClientError):
+    """Simulates aiohttp.ClientConnectorError."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(str(args[0]) if args else "connection error")
+
+
+class ServerDisconnectedError(ClientError):
+    """Simulates aiohttp.ServerDisconnectedError."""
+
+
 aiohttp_module.ClientError = ClientError
+aiohttp_module.ClientConnectorError = ClientConnectorError
+aiohttp_module.ServerDisconnectedError = ServerDisconnectedError
 aiohttp_module.ClientSession = ClientSession
 sys.modules["aiohttp"] = aiohttp_module
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,494 @@
+"""Tests de la logique de réessai et de classification d'erreurs dans api.py."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.mel_collecte.api import MelCollecteAPI
+from custom_components.mel_collecte.const import (
+    MAX_RETRIES,
+    RETRY_BASE_DELAY,
+    PermanentError,
+    TransientError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Réponse HTTP factice configurable."""
+
+    def __init__(self, json_data=None, status: int = 200, headers: dict | None = None):
+        self._json = json_data or {}
+        self.status = status
+        self.headers = headers or {}
+
+    async def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise Exception(f"HTTP {self.status}")
+
+
+# ---------------------------------------------------------------------------
+# Tests de _classify_http_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyHttpError:
+    """Vérifie la classification des codes HTTP."""
+
+    def _call(self, status: int):
+        from custom_components.mel_collecte.api import _classify_http_error
+
+        _classify_http_error(status)
+
+    def test_400_is_permanent(self):
+        with pytest.raises(PermanentError):
+            self._call(400)
+
+    def test_401_is_permanent(self):
+        with pytest.raises(PermanentError):
+            self._call(401)
+
+    def test_403_is_permanent(self):
+        with pytest.raises(PermanentError):
+            self._call(403)
+
+    def test_404_is_permanent(self):
+        with pytest.raises(PermanentError):
+            self._call(404)
+
+    def test_422_is_permanent(self):
+        with pytest.raises(PermanentError):
+            self._call(422)
+
+    def test_429_is_transient(self):
+        with pytest.raises(TransientError):
+            self._call(429)
+
+    def test_500_is_transient(self):
+        with pytest.raises(TransientError):
+            self._call(500)
+
+    def test_503_is_transient(self):
+        with pytest.raises(TransientError):
+            self._call(503)
+
+
+# ---------------------------------------------------------------------------
+# Tests de last_error
+# ---------------------------------------------------------------------------
+
+
+class TestLastError:
+    """Vérifie que last_error est mis à jour correctement."""
+
+    @pytest.mark.asyncio
+    async def test_last_error_none_on_success(self):
+        """last_error est None après une requête réussie."""
+        session = MagicMock()
+        session.get = AsyncMock(
+            return_value=FakeResponse(
+                [
+                    {
+                        "data": {
+                            "features": [
+                                {
+                                    "geometry": {"coordinates": [3.0, 50.0]},
+                                    "properties": {"id": "X"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            )
+        )
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await api.geocode_address("5 rue Test")
+
+        assert api.last_error is None
+
+    @pytest.mark.asyncio
+    async def test_last_error_set_on_permanent_error(self):
+        """last_error est renseigné après une erreur permanente."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=404))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), pytest.raises(
+            PermanentError
+        ):
+            await api.geocode_address("adresse inconnue")
+
+        assert api.last_error is not None
+        assert "404" in api.last_error
+
+    @pytest.mark.asyncio
+    async def test_last_error_set_on_transient_error_exhausted(self):
+        """last_error est renseigné après épuisement des tentatives transitoires."""
+        import aiohttp
+
+        session = MagicMock()
+        session.get = AsyncMock(side_effect=aiohttp.ClientConnectorError("timeout"))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), pytest.raises(
+            TransientError
+        ):
+            await api.geocode_address("5 rue Test")
+
+        assert api.last_error is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests de réessai — erreurs réseau
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnNetworkErrors:
+    """Vérifie les réessais sur erreurs réseau."""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_client_connector_error(self):
+        """ClientConnectorError déclenche MAX_RETRIES+1 tentatives au total."""
+        import aiohttp
+
+        session = MagicMock()
+        session.get = AsyncMock(
+            side_effect=aiohttp.ClientConnectorError("connection refused")
+        )
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+        assert mock_sleep.call_count == MAX_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_retries_on_server_disconnected(self):
+        """ServerDisconnectedError déclenche les réessais."""
+        import aiohttp
+
+        session = MagicMock()
+        session.get = AsyncMock(side_effect=aiohttp.ServerDisconnectedError())
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_timeout_error(self):
+        """asyncio.TimeoutError déclenche les réessais."""
+        session = MagicMock()
+        session.get = AsyncMock(side_effect=asyncio.TimeoutError())
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_third_attempt(self):
+        """Réussit après deux échecs réseau et un succès."""
+        import aiohttp
+
+        expected = [
+            {
+                "data": {
+                    "features": [
+                        {
+                            "geometry": {"coordinates": [3.0, 50.0]},
+                            "properties": {"id": "OK"},
+                        }
+                    ]
+                }
+            }
+        ]
+        session = MagicMock()
+        session.get = AsyncMock(
+            side_effect=[
+                aiohttp.ClientConnectorError("err"),
+                aiohttp.ClientConnectorError("err"),
+                FakeResponse(expected),
+            ]
+        )
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await api.geocode_address("5 rue Test")
+
+        assert result is not None
+        assert result["properties"]["id"] == "OK"
+        assert session.get.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests de réessai — erreurs HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnHttpErrors:
+    """Vérifie les réessais selon les codes HTTP."""
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_404(self):
+        """HTTP 404 ne déclenche pas de réessai."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=404))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with pytest.raises(PermanentError):
+                await api.geocode_address("adresse inconnue")
+
+        assert session.get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_401(self):
+        """HTTP 401 ne déclenche pas de réessai."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=401))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with pytest.raises(PermanentError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retry_on_500(self):
+        """HTTP 500 déclenche les réessais."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=500))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_503(self):
+        """HTTP 503 déclenche les réessais."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=503))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+
+# ---------------------------------------------------------------------------
+# Tests HTTP 429 avec Retry-After
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitHandling:
+    """Vérifie la gestion du HTTP 429 et de l'en-tête Retry-After."""
+
+    @pytest.mark.asyncio
+    async def test_respects_retry_after_header(self):
+        """Respect de l'en-tête Retry-After sur HTTP 429."""
+        retry_after = "5"
+        session = MagicMock()
+        # Deux 429 puis succès
+        good_response = FakeResponse(
+            [
+                {
+                    "data": {
+                        "features": [
+                            {
+                                "geometry": {"coordinates": [3.0, 50.0]},
+                                "properties": {"id": "X"},
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        session.get = AsyncMock(
+            side_effect=[
+                FakeResponse(status=429, headers={"Retry-After": retry_after}),
+                FakeResponse(status=429, headers={"Retry-After": retry_after}),
+                good_response,
+            ]
+        )
+        api = MelCollecteAPI(session)
+
+        sleep_calls = []
+
+        async def fake_sleep(delay):
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            result = await api.geocode_address("5 rue Test")
+
+        assert result is not None
+        # Les délais de sleep doivent correspondre à la valeur Retry-After
+        assert sleep_calls[0] == pytest.approx(5.0)
+        assert sleep_calls[1] == pytest.approx(5.0)
+
+    @pytest.mark.asyncio
+    async def test_uses_backoff_without_retry_after(self):
+        """Utilise le backoff exponentiel si Retry-After est absent."""
+        session = MagicMock()
+        good_response = FakeResponse(
+            [
+                {
+                    "data": {
+                        "features": [
+                            {
+                                "geometry": {"coordinates": [3.0, 50.0]},
+                                "properties": {"id": "X"},
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        session.get = AsyncMock(
+            side_effect=[
+                FakeResponse(status=429, headers={}),
+                good_response,
+            ]
+        )
+        api = MelCollecteAPI(session)
+
+        sleep_calls = []
+
+        async def fake_sleep(delay):
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await api.geocode_address("5 rue Test")
+
+        # Première tentative (attempt=0) → délai = RETRY_BASE_DELAY * 2^0 = 1s
+        assert sleep_calls[0] == pytest.approx(RETRY_BASE_DELAY * (2**0))
+
+    @pytest.mark.asyncio
+    async def test_exhausted_429_raises_transient(self):
+        """HTTP 429 persistant lève TransientError après MAX_RETRIES tentatives."""
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=429, headers={}))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+
+# ---------------------------------------------------------------------------
+# Tests du backoff exponentiel
+# ---------------------------------------------------------------------------
+
+
+class TestExponentialBackoff:
+    """Vérifie la progression du délai entre les tentatives."""
+
+    @pytest.mark.asyncio
+    async def test_backoff_progression(self):
+        """Le délai double à chaque tentative (jusqu'au cap RETRY_MAX_DELAY)."""
+        import aiohttp
+
+        session = MagicMock()
+        session.get = AsyncMock(side_effect=aiohttp.ClientConnectorError("err"))
+        api = MelCollecteAPI(session)
+
+        sleep_calls = []
+
+        async def fake_sleep(delay):
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            with pytest.raises(TransientError):
+                await api.geocode_address("5 rue Test")
+
+        assert len(sleep_calls) == MAX_RETRIES
+        for i, delay in enumerate(sleep_calls):
+            expected = min(RETRY_BASE_DELAY * (2**i), 30)
+            assert delay == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Tests d'intégration fetch_waste_collections et fetch_alerts
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMethodsRetry:
+    """Vérifie que fetch_waste_collections et fetch_alerts bénéficient aussi du retry."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_waste_collections_retries_on_500(self):
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=500))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.fetch_waste_collections("876", "ADDR_ID")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_waste_collections_no_retry_on_404(self):
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=404))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with pytest.raises(PermanentError):
+                await api.fetch_waste_collections("876", "ADDR_ID")
+
+        assert session.get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_alerts_retries_on_503(self):
+        session = MagicMock()
+        session.get = AsyncMock(return_value=FakeResponse(status=503))
+        api = MelCollecteAPI(session)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TransientError):
+                await api.fetch_alerts("876", "ADDR_ID")
+
+        assert session.get.call_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_normal_request_unaffected(self):
+        """Une requête normale (200) fonctionne sans réessai."""
+        session = MagicMock()
+        session.get = AsyncMock(
+            return_value=FakeResponse({"hits": {"hits": [{"_source": {"id": "C1"}}]}})
+        )
+        api = MelCollecteAPI(session)
+
+        result = await api.fetch_waste_collections("876", "ADDR_ID")
+
+        assert result == [{"id": "C1"}]
+        assert session.get.call_count == 1


### PR DESCRIPTION
## Résumé

Implémente la logique de réessai avec backoff exponentiel pour les appels API, ainsi qu'une classification fine des erreurs (transitoires vs permanentes).

Closes #10

---

## Changements

### `const.py`
- Nouvelles constantes de configuration du retry :
  - `MAX_RETRIES = 3`
  - `RETRY_BASE_DELAY = 1` (secondes)
  - `RETRY_MAX_DELAY = 30` (secondes)
- Hiérarchie d'exceptions :
  - `TransientError` — réseau, timeout, HTTP 429, HTTP 5xx → réessayable
  - `PermanentError` — HTTP 400, 401, 403, 404 → ne pas réessayer

### `api.py`
- Nouvelle méthode privée `_request_with_retry()` centralisant toute la logique de réessai
- Backoff exponentiel : 1 s, 2 s, 4 s entre les tentatives (plafonné à 30 s via `RETRY_MAX_DELAY`)
- Gestion de l'en-tête `Retry-After` sur HTTP 429 (prioritaire sur le backoff calculé)
- Erreurs permanentes (400, 401, 403, 404) levées immédiatement sans réessai
- Propriété `last_error` exposant le dernier message d'erreur pour le débogage
- Aucune nouvelle dépendance runtime (utilise uniquement `asyncio` et `aiohttp`, déjà disponibles via HA)

### `coordinator.py`
- `LOGGER.error` → `LOGGER.warning` pour les `UpdateFailed` (erreurs réseau attendues)
- Suivi interne `_last_update_success` (datetime) pour la fraîcheur des données
- Ajout de `last_update_success` (chaîne ISO 8601) dans le dictionnaire de données retourné

### `tests/conftest.py`
- Ajout de `ClientConnectorError` et `ServerDisconnectedError` dans le stub `aiohttp`

### `tests/test_retry.py` _(nouveau — 27 tests)_
- Classification HTTP (`_classify_http_error`) : 400, 401, 403, 404, 422 → PermanentError ; 429, 5xx → TransientError
- Réessais sur erreurs réseau : `ClientConnectorError`, `ServerDisconnectedError`, `asyncio.TimeoutError`
- Succès après 2 échecs (3ème tentative OK)
- Pas de réessai sur 404 / 401
- Réessais sur 500 / 503
- Gestion 429 : respect de `Retry-After`, fallback backoff sans header, épuisement → `TransientError`
- Progression du backoff exponentiel vérifiée
- Couverture de `fetch_waste_collections` et `fetch_alerts`
- Propriété `last_error`

### `docs/guide_utilisateur.md`
- Section **8.1 Logique de réessai et gestion des erreurs** avec tableau des catégories d'erreurs
- Documentation de `last_update_success` et du niveau de log `WARNING`

---

## Critères d'acceptation

- [x] Les appels API réessaient jusqu'à 3 fois sur les erreurs transitoires avec backoff exponentiel
- [x] Les réponses 429 sont gérées avec le délai `Retry-After` si présent
- [x] Les erreurs permanentes (400, 404) ne déclenchent pas de réessai
- [x] Après épuisement des tentatives, le coordinator marque la mise à jour comme échouée sans planter
- [x] `last_error` est accessible
- [x] Les mises à jour normales ne sont pas affectées
- [x] Aucune nouvelle dépendance runtime

## Tests

```
110 passed in 0.08s
```

Ruff ✅ | Black ✅ | Mypy ✅