### PR TITLE
feat: Implement Manual Refresh Service and Days Until Next Collection Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ L'intégration crée automatiquement les entités ci-dessous.
 |--------|------|-------------|
 | `calendar.collectes_des_dechets` | Calendrier | Toutes les collectes à venir (90 jours) |
 | `sensor.prochaine_collecte` | Capteur | Prochaine collecte avec attributs détaillés |
+| `sensor.jours_avant_prochaine_collecte` | Capteur | Nombre de jours (entier) avant la prochaine collecte |
 | `sensor.collecte_<type>` | Capteur | Un capteur par type (`dechets_verts`, `emballages`, …) |
 | `sensor.alertes_collecte` | Capteur | Alertes actives du service |
 
@@ -158,7 +159,7 @@ Le parser (`parser.py`) convertit les chaînes `opening_hours` (ex: `week 1-52/2
 
 **Horaires incorrects ?** Les données viennent de Publidata. Ouvrez une issue si un format est mal parsé.
 
-**Comment_forcer un rafraîchissement ?** Redémarrez Home Assistant ou supprimez/réinstallez l'intégration.
+**Comment_forcer un rafraîchissement ?** Vous pouvez appeler le service `mel_collecte.force_refresh` (disponible dans *Outils de développement → Services*) pour rafraîchir les données immédiatement.
 
 ---
 

--- a/_bmad-output/implementation-artifacts/spec-gh-12-force-refresh-and-days-sensor.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-12-force-refresh-and-days-sensor.md
@@ -1,0 +1,68 @@
+---
+title: 'Implement Force Refresh Service and Next Collection Days Sensor'
+type: 'feature'
+created: '2026-05-10T18:34:00'
+status: 'ready-for-dev'
+context: []
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Users must currently wait for the scheduled coordinator refresh (up to 7 days) or restart Home Assistant to get updated collection data. There is no manual refresh method and no simple integer sensor for days until the next collection, making dashboard logic complex.
+
+**Approach:** We will register a Home Assistant service `mel_collecte.force_refresh` in the integration's setup that loops through instances and calls `async_request_refresh()` on their coordinators. We will also add a `MelCollecteNextCollectionDaysSensor` returning the integer days until the next collection. Finally, we will update `README.md` and `docs/guide_utilisateur.md` in French.
+
+## Boundaries & Constraints
+
+**Always:** 
+- Sensor state must return an integer or `None` if no upcoming collection exists.
+- Service must support optional `entry_id` filtering.
+- Documentation updates must be in French.
+
+**Ask First:** 
+- Any architectural changes to the coordinator.
+- Changing the unique ID of existing sensors.
+
+**Never:** 
+- Do not introduce blocking code in async contexts.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Valid refresh | Service `mel_collecte.force_refresh` called | Coordinator triggers `async_request_refresh()` | N/A |
+| Future event exists | Upcoming event in 2 days | Sensor `native_value` is `2` | N/A |
+| No future events | No events in data | Sensor `native_value` is `None` | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `custom_components/mel_collecte/__init__.py` -- Add service registration and logic.
+- `custom_components/mel_collecte/sensor.py` -- Add `MelCollecteNextCollectionDaysSensor`.
+- `README.md` -- Document new service and sensor.
+- `docs/guide_utilisateur.md` -- Document new service and sensor.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [ ] `custom_components/mel_collecte/__init__.py` -- Add `force_refresh` service to `async_setup_entry` using `hass.services.async_register`. -- Enables manual update triggers.
+- [ ] `custom_components/mel_collecte/__init__.py` -- Unregister `force_refresh` service in `async_unload_entry`. -- Clean up on integration removal.
+- [ ] `custom_components/mel_collecte/sensor.py` -- Add `MelCollecteNextCollectionDaysSensor` class inheriting from `MelCollecteBaseSensor`. -- Provides integer days until next event.
+- [ ] `custom_components/mel_collecte/sensor.py` -- Update `async_setup_entry` to append `MelCollecteNextCollectionDaysSensor` to `entities`. -- Registers the new sensor.
+- [ ] `README.md` -- Add `sensor.jours_avant_prochaine_collecte` and the `force_refresh` service to the documentation in French. -- Keep docs up-to-date.
+- [ ] `docs/guide_utilisateur.md` -- Add `sensor.jours_avant_prochaine_collecte` and the `force_refresh` service to the user guide in French. -- Keep user guide up-to-date.
+- [ ] `tests/test_api.py` or similar -- Ensure tests are passing or updated if needed, run `make lint` and `make test`. -- Verify code quality.
+
+**Acceptance Criteria:**
+- Given Home Assistant running, when calling `mel_collecte.force_refresh`, then the coordinator updates immediately.
+- Given an upcoming event, when reading `sensor.jours_avant_prochaine_collecte`, then the state is an integer of days.
+- Given no upcoming events, when reading `sensor.jours_avant_prochaine_collecte`, then the state is `None`.
+
+## Verification
+
+**Commands:**
+- `make lint` -- expected: Pass without errors.
+- `make test` -- expected: Tests run successfully.

--- a/custom_components/mel_collecte/__init__.py
+++ b/custom_components/mel_collecte/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
 
 try:  # pragma: no cover - fallback pour exécution hors HA (tests)
     from homeassistant.helpers import aiohttp_client
@@ -67,6 +68,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
 
+    async def async_handle_refresh_service(call):
+        """Force refresh of all or specific entries."""
+        entry_id = call.data.get("entry_id")
+        if entry_id:
+            if entry_id in hass.data.get(DOMAIN, {}):
+                coord = hass.data[DOMAIN][entry_id].get(DATA_COORDINATOR)
+                if coord:
+                    await coord.async_request_refresh()
+        else:
+            for instance_id in hass.data.get(DOMAIN, {}):
+                coord = hass.data[DOMAIN][instance_id].get(DATA_COORDINATOR)
+                if coord:
+                    await coord.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        "force_refresh",
+        async_handle_refresh_service,
+        schema=vol.Schema({vol.Optional("entry_id"): str}),
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -76,4 +98,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, "force_refresh")
     return unload_ok

--- a/custom_components/mel_collecte/sensor.py
+++ b/custom_components/mel_collecte/sensor.py
@@ -23,6 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
 
     entities: list[SensorEntity] = [
         MelCollecteNextSensor(coordinator, entry),
+        MelCollecteNextCollectionDaysSensor(coordinator, entry),
         MelCollecteAlertSensor(coordinator, entry),
     ]
 
@@ -89,6 +90,43 @@ class MelCollecteNextSensor(MelCollecteBaseSensor):
             "mode": event["collection_mode"],
             "debut": event["start"].isoformat(),
             "fin": event["end"].isoformat(),
+        }
+
+    def _next_event(self):
+        now = dt_util.utcnow()
+        data = self._coordinator.data or {}
+        for event in data.get("events", []):
+            if event["start"] >= now:
+                return event
+        return None
+
+
+class MelCollecteNextCollectionDaysSensor(MelCollecteBaseSensor):
+    """Capteur indiquant le nombre de jours avant la prochaine collecte."""
+
+    def __init__(self, coordinator, entry):
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_days_until_next_collection"
+        self._attr_name = "Jours avant prochaine collecte"
+        self._attr_icon = "mdi:calendar-clock"
+        self._attr_native_unit_of_measurement = "days"
+
+    @property
+    def native_value(self):
+        event = self._next_event()
+        if event:
+            delta = event["start"].date() - dt_util.now().date()
+            return delta.days
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        event = self._next_event()
+        if not event:
+            return {}
+        return {
+            "next_collection_date": event["start"].isoformat(),
+            "next_collection_type": event.get("garbage_types_friendly", "Inconnu"),
         }
 
     def _next_event(self):

--- a/custom_components/mel_collecte/services.yaml
+++ b/custom_components/mel_collecte/services.yaml
@@ -1,0 +1,9 @@
+force_refresh:
+  name: "Forcer le rafraîchissement"
+  description: "Force la mise à jour immédiate des données de collecte auprès de l'API Publidata."
+  fields:
+    entry_id:
+      name: "ID de l'intégration"
+      description: "Identifiant spécifique de l'intégration à mettre à jour (optionnel, mettra à jour toutes les instances par défaut)."
+      example: "0123456789abcdef"
+      advanced: true

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -63,6 +63,7 @@ L'intégration permet de personnaliser plusieurs paramètres après l'ajout init
   - `types_friendly` (libellés français : "Ordures ménagères résiduelles", "Déchets verts"…),
   - `mode` (ramassage, dépôt, RDV…),
   - `debut` / `fin`.
+- `sensor.jours_avant_prochaine_collecte` : indique le nombre entier de jours restants avant la prochaine collecte.
 - `sensor.collecte_<type>` : un capteur par type détecté (`sensor.collecte_dechets_verts`, etc.).
 - `sensor.alertes_collecte` : nombre d'alertes actives du service de collecte, avec attributs :
   - `alerts` : liste complète des alertes avec détails (id, nom, type, message, dates),
@@ -170,6 +171,7 @@ Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, �
 - **Horaires incorrects** : les données Publidata font foi. Les événements sont générés à partir des créneaux `opening_hours`. Si un format inattendu apparaît, ouvrir une issue sur le dépôt.
 - **Trash Card sans affichage** : vérifier que l'entité calendrier est bien configurée dans la carte et que les patterns correspondent aux libellés exacts.
 - **Types de déchets non affichés** : vérifier dans les options que les types souhaités sont bien sélectionnés. Un type non sélectionné n'apparaît ni dans les capteurs ni dans le calendrier.
+- **Rafraîchissement manuel** : Vous pouvez appeler le service `mel_collecte.force_refresh` via *Outils de développement → Services* pour forcer une mise à jour immédiate sans redémarrer Home Assistant.
 
 ### 8.1 Logique de réessai et gestion des erreurs
 


### PR DESCRIPTION
Resolves #12

This PR introduces:
- A new Home Assistant service `mel_collecte.force_refresh` allowing users to manually trigger data updates from Publidata immediately.
- A new sensor `sensor.jours_avant_prochaine_collecte` providing an integer count of the days remaining until the next collection event.
- Updated user documentation and README in French to reflect these additions.

All linting (`make lint`) and tests (`make test`) pass successfully.