### PR TITLE
feat: Add per-type days-until sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ L'intégration crée automatiquement les entités ci-dessous.
 | `sensor.prochaine_collecte` | Capteur | Prochaine collecte avec attributs détaillés |
 | `sensor.jours_avant_prochaine_collecte` | Capteur | Nombre de jours (entier) avant la prochaine collecte |
 | `sensor.collecte_<type>` | Capteur | Un capteur par type (`dechets_verts`, `emballages`, …) |
+| `sensor.collecte_<type>_dans` | Capteur | Nombre de jours avant la prochaine collecte pour ce type |
 | `sensor.alertes_collecte` | Capteur | Alertes actives du service |
 
 **Attributs disponibles** : `types`, `types_friendly`, `mode`, `debut`, `fin`, `accepted_waste`, `rejected_waste`.

--- a/custom_components/mel_collecte/sensor.py
+++ b/custom_components/mel_collecte/sensor.py
@@ -36,6 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
                 continue
             seen_types.add(garbage_type)
             entities.append(MelCollecteTypeSensor(coordinator, entry, garbage_type))
+            entities.append(MelCollecteTypeDaysSensor(coordinator, entry, garbage_type))
 
     async_add_entities(entities)
 
@@ -167,6 +168,46 @@ class MelCollecteTypeSensor(MelCollecteBaseSensor):
             "types_friendly": event.get("garbage_types_friendly"),
             "debut": event["start"].isoformat(),
             "fin": event["end"].isoformat(),
+        }
+
+    def _next_event_for_type(self):
+        now = dt_util.utcnow()
+        data = self._coordinator.data or {}
+        for event in data.get("events", []):
+            if event["start"] >= now and self._type in event["garbage_types"]:
+                return event
+        return None
+
+
+class MelCollecteTypeDaysSensor(MelCollecteBaseSensor):
+    """Capteur indiquant le nombre de jours avant la prochaine collecte d'un type spécifique."""
+
+    def __init__(self, coordinator, entry, garbage_type: str):
+        super().__init__(coordinator, entry)
+        self._type = garbage_type
+        self._attr_unique_id = f"{entry.entry_id}_type_{garbage_type}_days"
+        self._label = garbage_label(garbage_type)
+        self._attr_name = f"Collecte {self._label} dans"
+        self._attr_native_unit_of_measurement = "jours"
+        self._attr_icon = "mdi:calendar-clock"
+
+    @property
+    def native_value(self):
+        event = self._next_event_for_type()
+        if event:
+            delta = event["start"].date() - dt_util.now().date()
+            return delta.days
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        event = self._next_event_for_type()
+        if not event:
+            return {}
+        return {
+            "prochaine_collecte": event["start"].isoformat(),
+            "type": self._type,
+            "type_libelle": self._label,
         }
 
     def _next_event_for_type(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,6 +8,7 @@ from custom_components.mel_collecte.calendar import MelCollecteCalendar
 from custom_components.mel_collecte.sensor import (
     MelCollecteNextSensor,
     MelCollecteTypeSensor,
+    MelCollecteTypeDaysSensor,
     MelCollecteAlertSensor,
 )
 
@@ -443,6 +444,58 @@ class TestSensorEdgeCases:
         sensor = MelCollecteTypeSensor(coordinator, entry, "omr")
 
         assert "Ordures ménagères résiduelles" in sensor.name
+
+    def test_type_days_sensor_calculates_days(self):
+        """MelCollecteTypeDaysSensor calcule correctement le nombre de jours."""
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        events = [
+            {
+                "collection_id": "col_omr",
+                "garbage_types": ["omr"],
+                "garbage_types_friendly": ["Ordures ménagères résiduelles"],
+                "collection_mode": "door",
+                "start": now + timedelta(days=2),
+                "end": now + timedelta(days=2, hours=2),
+                "name": "OMR Collection",
+            },
+        ]
+        coordinator = DummyCoordinator(events, [])
+        entry = SimpleNamespace(entry_id="test")
+        sensor = MelCollecteTypeDaysSensor(coordinator, entry, "omr")
+
+        with patch(
+            "custom_components.mel_collecte.sensor.dt_util.utcnow", return_value=now
+        ), patch(
+            "custom_components.mel_collecte.sensor.dt_util.now",
+            return_value=now,
+            create=True,
+        ):
+            value = sensor.native_value
+            attrs = sensor.extra_state_attributes
+
+        assert value == 2
+        assert attrs["type"] == "omr"
+        assert attrs["prochaine_collecte"] == events[0]["start"].isoformat()
+
+    def test_type_days_sensor_returns_none_if_no_event(self):
+        """MelCollecteTypeDaysSensor retourne None si aucun événement."""
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        coordinator = DummyCoordinator([], [])
+        entry = SimpleNamespace(entry_id="test")
+        sensor = MelCollecteTypeDaysSensor(coordinator, entry, "omr")
+
+        with patch(
+            "custom_components.mel_collecte.sensor.dt_util.utcnow", return_value=now
+        ), patch(
+            "custom_components.mel_collecte.sensor.dt_util.now",
+            return_value=now,
+            create=True,
+        ):
+            value = sensor.native_value
+            attrs = sensor.extra_state_attributes
+
+        assert value is None
+        assert attrs == {}
 
     def test_alert_sensor_with_alerts_native_value_is_count(self):
         """MelCollecteAlertSensor retourne le nombre d'alertes."""


### PR DESCRIPTION
This PR adds a new `sensor.collecte_<type>_dans` entity for each active garbage type showing the days until next collection, and adds the exact next collection date as an attribute. It also updates the documentation to list this new sensor. Closes #13