### PR TITLE
feat: automation trigger events for upcoming collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ pattern:
     pattern: Emballages recyclables
 ```
 
+### Événements et Automatisations
+
+L'intégration déclenche un événement natif `mel_collecte.collection_upcoming` lorsqu'une collecte approche, idéal pour vos automatisations sans nécessiter de modèles (templates) complexes.
+
+* Le délai de déclenchement (par défaut : 24h avant la collecte) est modifiable via le service `mel_collecte.set_collection_offset`.
+* Les données de l'événement incluent : `collection_id`, `garbage_types`, `garbage_types_friendly`, `start`, `hours_until`, etc.
+
 ---
 
 ## Architecture

--- a/_bmad-output/implementation-artifacts/spec-gh-14-trigger-events.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-14-trigger-events.md
@@ -1,0 +1,70 @@
+---
+title: 'Add automation trigger events for upcoming collections (Issue 14)'
+type: 'feature'
+created: '2026-05-10T18:52:14Z'
+status: 'done'
+baseline_commit: '829e02e9ec02c6f2b6b419092f699c330da35a4c'
+context: []
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Users must currently use complex template-based triggers polling sensor values to trigger automations before a collection. A native event-based approach would be cleaner and more efficient.
+
+**Approach:** Fire a custom Home Assistant event (`mel_collecte.collection_upcoming`) with configurable lead time before a collection occurs, ensuring it only fires once per collection. A new service `mel_collecte.set_collection_offset` will allow users to configure the lead time.
+
+## Boundaries & Constraints
+
+**Always:** 
+- The event must contain `entry_id`, `address`, `collection_id`, `collection_name`, `garbage_types`, `garbage_types_friendly`, `start`, `end`, `days_until`, and `hours_until`.
+- Fire the event exactly once per collection (prevent automation spam).
+- Store `fired_events` state so we do not re-fire. Default offset is 24 hours.
+
+**Ask First:** 
+- Adding UI config options for the offset. The service is enough for now.
+
+**Never:** 
+- Break existing sensors or the calendar.
+- Fire the event repeatedly on every coordinator update for the same collection.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Collection approaching | Coordinator updates, a collection is exactly within the configured hours offset | Event `mel_collecte.collection_upcoming` is fired. | N/A |
+| Already fired event | Coordinator updates, collection still within offset but event already fired | Event is NOT fired again for the same collection. | N/A |
+| Change offset service | User calls `set_collection_offset` | The internal offset value is updated. New collections will use this offset. | Handled by service schema validation |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `custom_components/mel_collecte/const.py` -- Define event name `EVENT_COLLECTION_UPCOMING` and default offset.
+- `custom_components/mel_collecte/coordinator.py` -- Add `fired_events` tracking state, so we know what events have been fired.
+- `custom_components/mel_collecte/__init__.py` -- Add listener `_async_fire_events` to the coordinator, implement logic to check collections and fire events, and register the new service.
+- `custom_components/mel_collecte/services.yaml` -- Document the new service `set_collection_offset`.
+- `tests/test_init.py` or similar -- Unit tests for the new event firing and service.
+- `README.md` & `docs/guide_utilisateur.md` -- Update documentation in French.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [ ] `custom_components/mel_collecte/const.py` -- Add `EVENT_COLLECTION_UPCOMING = "collection_upcoming"` and `DEFAULT_COLLECTION_OFFSET = 24`.
+- [ ] `custom_components/mel_collecte/coordinator.py` -- Add `self.fired_events = set()` and `self.collection_offset_hours = DEFAULT_COLLECTION_OFFSET`.
+- [ ] `custom_components/mel_collecte/__init__.py` -- Register service `set_collection_offset`, register listener on coordinator, loop through `coordinator.data` (upcoming collections) and fire event if `hours_until <= collection_offset_hours` and not in `fired_events`. Add to `fired_events`.
+- [ ] `custom_components/mel_collecte/services.yaml` -- Document `set_collection_offset`.
+- [ ] `tests/test_events.py` -- Create new test file to verify `set_collection_offset` and event firing logic.
+- [ ] `README.md` -- Document new events and automation example in French.
+- [ ] `docs/guide_utilisateur.md` -- Document new events in French.
+
+**Acceptance Criteria:**
+- Given a collection is approaching, when the time to collection becomes less than or equal to the offset, then an event `mel_collecte.collection_upcoming` is fired once.
+- Given the `set_collection_offset` service is called, then the internal offset state is updated and future checks respect the new offset.
+
+## Verification
+
+**Commands:**
+- `make test` -- expected: All tests pass.
+- `make lint` -- expected: Linting passes.

--- a/custom_components/mel_collecte/__init__.py
+++ b/custom_components/mel_collecte/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
 try:  # pragma: no cover - fallback pour exécution hors HA (tests)
@@ -28,6 +29,7 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_VISIBLE_TYPES,
     DOMAIN,
+    EVENT_COLLECTION_UPCOMING,
 )
 from .coordinator import MelCollecteCoordinator
 
@@ -68,6 +70,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
 
+    async def _async_fire_events() -> None:
+        if not coordinator.data:
+            return
+
+        now = dt_util.utcnow()
+        for event in coordinator.data.get("events", []):
+            start = event["start"]
+            time_until = start - now
+            hours_until = time_until.total_seconds() / 3600
+
+            if 0 <= hours_until <= coordinator.collection_offset_hours:
+                event_key = (event["collection_id"], start.isoformat())
+                if event_key not in coordinator.fired_events:
+                    coordinator.fired_events.add(event_key)
+
+                    payload = {
+                        "entry_id": entry.entry_id,
+                        "address": entry.data.get("address"),
+                        "collection_id": event["collection_id"],
+                        "collection_name": event.get("name"),
+                        "garbage_types": event["garbage_types"],
+                        "garbage_types_friendly": event["garbage_types_friendly"],
+                        "start": start.isoformat(),
+                        "end": event["end"].isoformat(),
+                        "days_until": time_until.days,
+                        "hours_until": int(hours_until),
+                    }
+                    hass.bus.async_fire(
+                        f"{DOMAIN}.{EVENT_COLLECTION_UPCOMING}", payload
+                    )
+
+    entry.async_on_unload(coordinator.async_add_listener(_async_fire_events))
+
     async def async_handle_refresh_service(call):
         """Force refresh of all or specific entries."""
         entry_id = call.data.get("entry_id")
@@ -89,6 +124,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         schema=vol.Schema({vol.Optional("entry_id"): str}),
     )
 
+    async def async_handle_set_offset_service(call):
+        """Configure event lead time (offset)."""
+        entry_id = call.data.get("entry_id")
+        hours_before = call.data.get("hours_before", 24)
+        if entry_id:
+            if entry_id in hass.data.get(DOMAIN, {}):
+                coord = hass.data[DOMAIN][entry_id].get(DATA_COORDINATOR)
+                if coord:
+                    coord.collection_offset_hours = hours_before
+        else:
+            for instance_id in hass.data.get(DOMAIN, {}):
+                coord = hass.data[DOMAIN][instance_id].get(DATA_COORDINATOR)
+                if coord:
+                    coord.collection_offset_hours = hours_before
+
+    hass.services.async_register(
+        DOMAIN,
+        "set_collection_offset",
+        async_handle_set_offset_service,
+        schema=vol.Schema(
+            {
+                vol.Optional("entry_id"): str,
+                vol.Required("hours_before"): vol.Coerce(int),
+            }
+        ),
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -100,4 +162,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         if not hass.data[DOMAIN]:
             hass.services.async_remove(DOMAIN, "force_refresh")
+            hass.services.async_remove(DOMAIN, "set_collection_offset")
     return unload_ok

--- a/custom_components/mel_collecte/const.py
+++ b/custom_components/mel_collecte/const.py
@@ -3,6 +3,9 @@
 DOMAIN = "mel_collecte"
 DATA_COORDINATOR = "coordinator"
 
+EVENT_COLLECTION_UPCOMING = "collection_upcoming"
+DEFAULT_COLLECTION_OFFSET = 24
+
 GEO_URL = "https://api.publidata.io/v2/geocoder"
 SEARCH_URL = "https://api.publidata.io/v2/search"
 

--- a/custom_components/mel_collecte/coordinator.py
+++ b/custom_components/mel_collecte/coordinator.py
@@ -15,6 +15,7 @@ from .const import (
     DEFAULT_LOOKAHEAD_DAYS,
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_VISIBLE_TYPES,
+    DEFAULT_COLLECTION_OFFSET,
     alert_label,
     garbage_label,
 )
@@ -56,6 +57,9 @@ class MelCollecteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self._address_payload: dict[str, Any] | None = None
         self._last_update_success: datetime | None = None
+
+        self.fired_events: set[tuple[str, str]] = set()
+        self.collection_offset_hours = DEFAULT_COLLECTION_OFFSET
 
     async def _async_update_data(self) -> dict[str, Any]:
         try:

--- a/custom_components/mel_collecte/services.yaml
+++ b/custom_components/mel_collecte/services.yaml
@@ -7,3 +7,23 @@ force_refresh:
       description: "Identifiant spécifique de l'intégration à mettre à jour (optionnel, mettra à jour toutes les instances par défaut)."
       example: "0123456789abcdef"
       advanced: true
+
+set_collection_offset:
+  name: "Définir le délai d'alerte de collecte"
+  description: "Configure le nombre d'heures avant une collecte pour le déclenchement de l'événement mel_collecte.collection_upcoming."
+  fields:
+    hours_before:
+      name: "Heures avant la collecte"
+      description: "Nombre d'heures (par défaut: 24)."
+      example: "24"
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 168
+          mode: box
+    entry_id:
+      name: "ID de l'intégration"
+      description: "Identifiant spécifique de l'intégration (optionnel)."
+      example: "0123456789abcdef"
+      advanced: true

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -159,9 +159,37 @@ Cette carte affiche toutes les alertes actives avec leur type (⚠️ Alerte, �
 
 ## 7. Automatisations possibles
 
-- **Notification la veille** : déclencher à 20h si `sensor.collecte_dechets_verts` est à moins de 24h.
+### 7.1 Événements natifs (Nouveau)
+
+L'intégration déclenche automatiquement un événement `mel_collecte.collection_upcoming` lorsqu'une collecte approche. Cela permet de créer des automatisations simples sans utiliser de modèles (templates).
+
+**Configuration du délai :**
+Par défaut, l'événement est déclenché 24 heures avant le début de la collecte. Vous pouvez modifier ce délai via le service `mel_collecte.set_collection_offset` :
+```yaml
+service: mel_collecte.set_collection_offset
+data:
+  hours_before: 12
+```
+
+**Exemple d'automatisation :**
+```yaml
+automation:
+  - trigger:
+      - platform: event
+        event_type: mel_collecte.collection_upcoming
+    condition:
+      - condition: template
+        value_template: "{{ trigger.event.data.garbage_types | first == 'omr' }}"
+    action:
+      - service: notify.mobile_app
+        data:
+          message: "Pensez à sortir la poubelle grise dans {{ trigger.event.data.hours_until }} heures !"
+```
+
+### 7.2 Autres automatisations
+- **Notification la veille** : déclencher à 20h si `sensor.collecte_dechets_verts_dans` est à 1.
 - **Rappel vocal** : utiliser `sensor.prochaine_collecte` dans un script TTS.
-- **Gestion des bacs** : combiner avec `input_boolean` pour savoir quel bac est sorti.
+- **Gestion des bacs** : combiner avec un `input_boolean` pour savoir quel bac est sorti.
 
 ---
 

--- a/tests/test_init_events.py
+++ b/tests/test_init_events.py
@@ -1,0 +1,99 @@
+"""Tests pour les événements et services dans __init__.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from custom_components.mel_collecte import async_setup_entry, async_unload_entry
+from custom_components.mel_collecte.const import DOMAIN, EVENT_COLLECTION_UPCOMING
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_services_and_fires_events():
+    """Test setup entry registers services and correctly fires the upcoming event."""
+    hass = MagicMock()
+    hass.data = {}
+
+    # Mock services
+    hass.services.async_register = MagicMock()
+    hass.services.async_remove = MagicMock()
+
+    # Mock config entries
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    # Mock bus
+    hass.bus.async_fire = MagicMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"address": "Test Address", "instance_id": "123"}
+    entry.options = {}
+
+    now = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    # Event starting in 12 hours (offset is default 24, so it should fire)
+    event_start = now + timedelta(hours=12)
+
+    with patch(
+        "custom_components.mel_collecte.api.MelCollecteAPI"
+    ) as mock_api_cls, patch(
+        "custom_components.mel_collecte.__init__.MelCollecteCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        create=True,
+    ) as _mock_refresh, patch(
+        "custom_components.mel_collecte.__init__.MelCollecteCoordinator.async_add_listener",
+        create=True,
+    ) as mock_add_listener, patch(
+        "homeassistant.util.dt.utcnow", return_value=now
+    ):
+
+        mock_api_cls.return_value = MagicMock()
+
+        result = await async_setup_entry(hass, entry)
+        assert result is True
+
+        assert hass.services.async_register.call_count == 2
+
+        coordinator = hass.data[DOMAIN]["test_entry"]["coordinator"]
+
+        coordinator.data = {
+            "events": [
+                {
+                    "collection_id": "col_1",
+                    "garbage_types": ["omr"],
+                    "garbage_types_friendly": ["OMR"],
+                    "start": event_start,
+                    "end": event_start + timedelta(hours=1),
+                    "name": "Collecte OMR",
+                }
+            ]
+        }
+
+        # Trigger the listener manually using the captured callback
+        listener = mock_add_listener.call_args[0][0]
+
+        import inspect
+
+        if inspect.iscoroutinefunction(listener):
+            await listener()
+        else:
+            listener()
+
+        assert hass.bus.async_fire.call_count == 1
+        args, kwargs = hass.bus.async_fire.call_args
+        assert args[0] == f"{DOMAIN}.{EVENT_COLLECTION_UPCOMING}"
+        assert args[1]["collection_id"] == "col_1"
+        assert args[1]["hours_until"] == 12
+
+        # Call it again to test that it doesn't fire twice
+        if inspect.iscoroutinefunction(listener):
+            await listener()
+        else:
+            listener()
+
+        assert hass.bus.async_fire.call_count == 1
+
+        unload_result = await async_unload_entry(hass, entry)
+        assert unload_result is True
+        assert hass.services.async_remove.call_count == 2


### PR DESCRIPTION
Closes #14

This PR adds the ability to trigger Home Assistant automations natively without templates using the `mel_collecte.collection_upcoming` event. It also adds the `mel_collecte.set_collection_offset` service to configure the lead-time before the collection.