### PR TITLE
fix: properly schedule async _async_fire_events coroutine

### DIFF
--- a/custom_components/mel_collecte/__init__.py
+++ b/custom_components/mel_collecte/__init__.py
@@ -101,7 +101,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         f"{DOMAIN}.{EVENT_COLLECTION_UPCOMING}", payload
                     )
 
-    entry.async_on_unload(coordinator.async_add_listener(_async_fire_events))
+    entry.async_on_unload(
+        coordinator.async_add_listener(
+            lambda: hass.async_create_task(_async_fire_events())
+        )
+    )
 
     async def async_handle_refresh_service(call):
         """Force refresh of all or specific entries."""

--- a/tests/test_init_events.py
+++ b/tests/test_init_events.py
@@ -50,6 +50,8 @@ async def test_async_setup_entry_registers_services_and_fires_events():
 
         mock_api_cls.return_value = MagicMock()
 
+        hass.async_create_task = AsyncMock()
+
         result = await async_setup_entry(hass, entry)
         assert result is True
 
@@ -80,6 +82,10 @@ async def test_async_setup_entry_registers_services_and_fires_events():
         else:
             listener()
 
+        if hass.async_create_task.called:
+            scheduled_coro = hass.async_create_task.call_args[0][0]
+            await scheduled_coro
+
         assert hass.bus.async_fire.call_count == 1
         args, kwargs = hass.bus.async_fire.call_args
         assert args[0] == f"{DOMAIN}.{EVENT_COLLECTION_UPCOMING}"
@@ -87,10 +93,15 @@ async def test_async_setup_entry_registers_services_and_fires_events():
         assert args[1]["hours_until"] == 12
 
         # Call it again to test that it doesn't fire twice
+        hass.async_create_task.reset_mock()
         if inspect.iscoroutinefunction(listener):
             await listener()
         else:
             listener()
+
+        if hass.async_create_task.called:
+            scheduled_coro = hass.async_create_task.call_args[0][0]
+            await scheduled_coro
 
         assert hass.bus.async_fire.call_count == 1
 


### PR DESCRIPTION
## Summary
Fixes a `RuntimeWarning: coroutine '_async_fire_events' was never awaited` that was occurring in the Home Assistant log.
### Root Cause
The `_async_fire_events` function is an `async def` (coroutine), but it was passed directly to `coordinator.async_add_listener()`, which expects synchronous callbacks. When the listener fired, the coroutine object was created but never executed.
### Fix
Wrap the async callback in a lambda that properly schedules it via `hass.async_create_task()`:
```python
# Before (broken)
entry.async_on_unload(coordinator.async_add_listener(_async_fire_events))
# After (fixed)
entry.async_on_unload(
    coordinator.async_add_listener(
        lambda: hass.async_create_task(_async_fire_events())
    )
)
```
### Note on recorder/info
The `Received unknown command: recorder/info` messages are **unrelated** to this integration - they're from the Home Assistant frontend or another integration making WebSocket requests that the server doesn't recognize. This can be safely ignored.
### Testing
- All 121 tests pass
- Lint checks (ruff, black, mypy) all pass
- Test updated to verify `async_create_task` is properly called